### PR TITLE
Feat/enable sdk to support multipart uploads

### DIFF
--- a/src/network/errors/upload.ts
+++ b/src/network/errors/upload.ts
@@ -7,3 +7,19 @@ export class UploadInvalidMnemonicError extends CodeError {
     Object.setPrototypeOf(this, UploadInvalidMnemonicError.prototype);
   }
 }
+
+export class UrlNotReceivedFromNetworkError extends CodeError {
+  constructor() {
+    super(ErrorCode.Upload.InvalidMnemonic, 'Url not received from network');
+
+    Object.setPrototypeOf(this, UrlNotReceivedFromNetworkError.prototype);
+  }
+}
+
+export class UrlsNotReceivedFromNetworkError extends CodeError {
+  constructor() {
+    super(ErrorCode.Upload.InvalidMnemonic, 'Urls not received from network');
+
+    Object.setPrototypeOf(this, UrlsNotReceivedFromNetworkError.prototype);
+  }
+}

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -93,7 +93,31 @@ export class Network {
       throw new DuplicatedIndexesError();
     }
 
-    return Network.startUpload(bucketId, payload, {
+    return Network.startUpload(
+      bucketId,
+      payload,
+      {
+        client: this.client,
+        appDetails: this.appDetails,
+        auth: this.auth,
+      },
+      parts,
+    );
+  }
+
+  finishUpload(bucketId: string, payload: FinishUploadPayload): Promise<FinishUploadResponse> {
+    const { index, shards } = payload;
+    if (!isHexString(index) || index.length !== 64) {
+      throw new InvalidFileIndexError();
+    }
+
+    for (const shard of shards) {
+      if (!uuidValidate(shard.uuid)) {
+        throw new Error('Invalid UUID');
+      }
+    }
+
+    return Network.finishUpload(bucketId, payload, {
       client: this.client,
       appDetails: this.appDetails,
       auth: this.auth,

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -180,9 +180,14 @@ export class Network {
     bucketId: string,
     payload: StartUploadPayload,
     { client, appDetails, auth }: NetworkRequestConfig,
+    parts = 1,
   ) {
     const headers = Network.headersWithBasicAuth(appDetails, auth);
-    return client.post<StartUploadResponse>(`/v2/buckets/${bucketId}/files/start`, payload, headers);
+    return client.post<StartUploadResponse>(
+      `/v2/buckets/${bucketId}/files/start?multiparts=${parts}`,
+      payload,
+      headers,
+    );
   }
 
   /**

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -124,7 +124,7 @@ export class Network {
     });
   }
 
-  finishUpload(bucketId: string, payload: FinishUploadPayload): Promise<FinishUploadResponse> {
+  finishMultipartUpload(bucketId: string, payload: FinishMultipartUploadPayload): Promise<FinishUploadResponse> {
     const { index, shards } = payload;
     if (!isHexString(index) || index.length !== 64) {
       throw new InvalidFileIndexError();
@@ -133,6 +133,13 @@ export class Network {
     for (const shard of shards) {
       if (!uuidValidate(shard.uuid)) {
         throw new Error('Invalid UUID');
+      }
+
+      if (!shard.UploadId) {
+        throw new Error('Missing UploadId');
+      }
+      if (!shard.parts) {
+        throw new Error('Missing parts');
       }
     }
 
@@ -144,11 +151,16 @@ export class Network {
   }
 
   getDownloadLinks(bucketId: string, fileId: string, token?: string): Promise<GetDownloadLinksResponse> {
-    return Network.getDownloadLinks(bucketId, fileId, {
+    return Network.getDownloadLinks(
+      bucketId,
+      fileId,
+      {
       client: this.client,
       appDetails: this.appDetails,
       auth: this.auth,
-    }, token);
+      },
+      token,
+    );
   }
 
   async deleteFile(bucketId: string, fileId: string): Promise<void> {

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -6,6 +6,7 @@ import {
   GetDownloadLinksResponse,
   NetworkRequestConfig,
   FinishUploadPayload,
+  FinishMultipartUploadPayload,
 } from './types';
 import { ApiUrl, AppDetails } from '../shared';
 import { HttpClient } from '../shared/http/client';
@@ -45,6 +46,22 @@ export class InvalidUploadSizeError extends Error {
     super('Invalid size');
 
     Object.setPrototypeOf(this, InvalidUploadSizeError.prototype);
+  }
+}
+
+export class FileTooSmallForMultipartError extends Error {
+  constructor() {
+    super('File is too small for multipart upload');
+
+    Object.setPrototypeOf(this, FileTooSmallForMultipartError.prototype);
+  }
+}
+
+export class InvalidMultipartValueError extends Error {
+  constructor() {
+    super('Invalid multipart value');
+
+    Object.setPrototypeOf(this, InvalidMultipartValueError.prototype);
   }
 }
 

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -198,7 +198,7 @@ export class Network {
    */
   private static finishUpload(
     bucketId: string,
-    payload: FinishUploadPayload,
+    payload: FinishUploadPayload | FinishMultipartUploadPayload,
     { client, appDetails, auth }: NetworkRequestConfig,
   ) {
     const headers = Network.headersWithBasicAuth(appDetails, auth);

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -10,8 +10,16 @@ export interface Shard {
   hash: Hash;
 }
 
+export interface ShardForMultipart extends Shard {
+  UploadId: string;
+  parts: {
+    PartNumber: number;
+    ETag: string;
+  };
+}
+
 export interface StartUploadResponse {
-  uploads: { index: number; uuid: Shard['uuid']; url: string }[];
+  uploads: { index: number; uuid: Shard['uuid']; url: string | null; urls: string[] | null; UploadId?: string }[];
 }
 export type FinishUploadResponse = BucketEntry;
 export interface BucketEntry {
@@ -59,11 +67,16 @@ export type FinishUploadPayload = {
   shards: Shard[];
 };
 
+export type FinishMultipartUploadPayload = {
+  index: string;
+  shards: ShardForMultipart[];
+};
+
 export type UploadFileFunction = (url: string) => Promise<Hash>;
-export type DownloadFileFunction = (
-  downloadables: DownloadableShard[],
-  fileSize: number
-) => Promise<void>;
+export type UploadFileMultipartFunction = (
+  urls: string[],
+) => Promise<{ hash: Hash; parts: { PartNumber: number; ETag: string } }>;
+export type DownloadFileFunction = (downloadables: DownloadableShard[], fileSize: number) => Promise<void>;
 
 export type BinaryData = {
   slice: (from: number, to: number) => BinaryData;

--- a/src/network/upload.ts
+++ b/src/network/upload.ts
@@ -39,7 +39,59 @@ export async function uploadFile(
 
   const finishUploadPayload = {
     index: index.toString('hex'),
-    shards: [{ hash, uuid }]
+    shards: [{ hash, uuid }],
+  };
+
+  const finishUploadResponse = await network.finishUpload(bucketId, finishUploadPayload);
+
+  return finishUploadResponse.id;
+}
+
+export async function uploadMultipartFile(
+  network: Network,
+  crypto: Crypto,
+  bucketId: string,
+  mnemonic: string,
+  fileSize: number,
+  encryptFile: EncryptFileFunction,
+  uploadMultiparts: UploadFileMultipartFunction,
+  parts = 1,
+): Promise<string> {
+  const mnemonicIsValid = crypto.validateMnemonic(mnemonic);
+
+  if (!mnemonicIsValid) {
+    throw new UploadInvalidMnemonicError();
+  }
+
+  const index = crypto.randomBytes(crypto.algorithm.ivSize);
+  const iv = index.slice(0, 16);
+  const key = await crypto.generateFileKey(mnemonic, bucketId, index);
+
+  const { uploads } = await network.startUpload(
+    bucketId,
+    {
+      uploads: [
+        {
+          index: 0,
+          size: fileSize,
+        },
+      ],
+    },
+    parts,
+  );
+
+  const [{ urls, uuid, UploadId }] = uploads;
+
+  if (!urls) {
+    throw new UrlsNotReceivedFromNetworkError();
+  }
+
+  await encryptFile(crypto.algorithm.type, key, iv);
+  const { hash, parts: uploadedPartsReference } = await uploadMultiparts(urls);
+
+  const finishUploadPayload = {
+    index: index.toString('hex'),
+    shards: [{ hash, uuid, UploadId, parts: uploadedPartsReference }],
   };
 
   const finishUploadResponse = await network.finishUpload(bucketId, finishUploadPayload);

--- a/src/network/upload.ts
+++ b/src/network/upload.ts
@@ -1,6 +1,6 @@
 import { Network } from '.';
-import { UploadInvalidMnemonicError } from './errors';
-import { Crypto, EncryptFileFunction, UploadFileFunction } from './types';
+import { UploadInvalidMnemonicError, UrlNotReceivedFromNetworkError, UrlsNotReceivedFromNetworkError } from './errors';
+import { Crypto, EncryptFileFunction, UploadFileFunction, UploadFileMultipartFunction } from './types';
 
 export async function uploadFile(
   network: Network,
@@ -29,6 +29,10 @@ export async function uploadFile(
   });
 
   const [{ url, uuid }] = uploads;
+
+  if (!url) {
+    throw new UrlNotReceivedFromNetworkError();
+  }
 
   await encryptFile(crypto.algorithm.type, key, iv);
   const hash = await uploadFile(url);

--- a/test/network/network.test.ts
+++ b/test/network/network.test.ts
@@ -94,7 +94,8 @@ describe('network ', () => {
         uploads: uploads.map(u => ({
           index: u.index,
           uuid: validUUID,
-          url
+          url,
+          urls: null,
         })),
       };
 
@@ -157,7 +158,7 @@ describe('network ', () => {
         uploads: [{ index: 0, size: 40 }],
       };
       const resolvesTo: StartUploadResponse = {
-        uploads: [{ index: validIndex, uuid: validUUID, url: '' }],
+        uploads: [{ index: validIndex, uuid: validUUID, url: '', urls: null }],
       };
       const callStub = sinon.stub(httpClient, 'post').resolves(resolvesTo);
       const staticStartUpload = jest.spyOn(Network.prototype as any, 'startUpload');
@@ -169,7 +170,7 @@ describe('network ', () => {
       expect(response).toEqual(resolvesTo);
       expect(staticStartUpload).toHaveBeenCalled();
       expect(callStub.firstCall.args).toEqual([
-        `/v2/buckets/${idBucket}/files/start`,
+        `/v2/buckets/${idBucket}/files/start?multiparts=1`,
         validStartUploadPayload,
         headers,
       ]);

--- a/test/network/upload.test.ts
+++ b/test/network/upload.test.ts
@@ -54,7 +54,8 @@ describe('network/upload', () => {
         uploads: [{
           url: fakeUrl,
           uuid: fakeUuid,
-          index: 0
+          index: 0,
+          urls: null,
         }]
       });
       const finishUploadStub = sinon.stub(network, 'finishUpload').resolves({


### PR DESCRIPTION
- Enables sdk for multipart upload
  - Makes endpoint with querystring for number of parts in startUpload 
  - Makes the uploadMultipart done by sdk host to return ETag and UploadNumber array.
  - Edits tests accordingly to receive `urls: null` whenever not using multiparts

Missing: method to abort a multipart. 