### PR TITLE
[_]: Replace toString by JSON.stringify to cover object cases

### DIFF
--- a/src/shared/http/client.ts
+++ b/src/shared/http/client.ts
@@ -172,7 +172,7 @@ export class HttpClient {
       } else {
         // TODO : remove when endpoints of updateMetadata(file/folder) are updated
         // after all clients use th SDK
-        errorMessage = String(response.data);
+        errorMessage = JSON.stringify(response.data);
       }
       errorStatus = response.status;
     } else if (error.request) {


### PR DESCRIPTION
Some errors received from the API was being reported as [object Object] when converting to string, because they were objects, this PR solves those cases where the error message is an object