### PR TITLE
[_]: hotfix(share-links): add plainPassword to create endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/share/index.ts
+++ b/src/drive/share/index.ts
@@ -67,8 +67,9 @@ export class Share {
         itemToken: payload.itemToken,
         bucket: payload.bucket,
         encryptedCode: payload.encryptedCode,
+        plainPassword: payload.password,
       },
-      this.headers(payload.password),
+      this.headers(),
     );
   }
 

--- a/src/drive/share/index.ts
+++ b/src/drive/share/index.ts
@@ -67,7 +67,7 @@ export class Share {
         itemToken: payload.itemToken,
         bucket: payload.bucket,
         encryptedCode: payload.encryptedCode,
-        plainPassword: payload.password,
+        plainPassword: payload.plainPassword,
       },
       this.headers(),
     );

--- a/src/drive/share/types.ts
+++ b/src/drive/share/types.ts
@@ -6,7 +6,7 @@ export interface GenerateShareLinkPayload {
   bucket: string;
   timesValid: number;
   encryptedCode: string;
-  password?: string;
+  plainPassword?: string;
 }
 
 export interface UpdateShareLinkPayload {


### PR DESCRIPTION
- For create now sends the plainPassword in body not in headers