### PR TITLE
[_]: feat change user path to users in changePassword

### DIFF
--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -73,13 +73,14 @@ export class Users {
    */
   public changePassword(payload: ChangePasswordPayload) {
     return this.client.patch(
-      '/user/password',
+      '/users/password',
       {
         currentPassword: payload.currentEncryptedPassword,
         newPassword: payload.newEncryptedPassword,
         newSalt: payload.newEncryptedSalt,
         mnemonic: payload.encryptedMnemonic,
         privateKey: payload.encryptedPrivateKey,
+        encryptVersion: payload.encryptVersion,
       },
       this.headers(),
     );

--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -4,6 +4,7 @@ import { HttpClient } from '../../shared/http/client';
 import { UserSettings } from '../../shared/types/userSettings';
 import {
   ChangePasswordPayload,
+  ChangePasswordPayloadNew,
   CheckChangeEmailExpirationResponse,
   FriendInvite,
   InitializeUserResponse,
@@ -95,12 +96,32 @@ export class Users {
   }
 
   /**
-   * Updates the authentication credentials and invalidates previous tokens
+   * Updates the authentication credentials and invalidates previous tokens (Legacy backend (drive-server))
    * @param payload
    *
    * @returns {Promise<{token: string, newToken: string}>} A promise that returns new tokens for this user.
    */
-  public changePassword(payload: ChangePasswordPayload): Promise<{ token: string; newToken: string }> {
+  public changePasswordLegacy(payload: ChangePasswordPayload): Promise<{ token: string; newToken: string }> {
+    return this.client.patch(
+      '/user/password',
+      {
+        currentPassword: payload.currentEncryptedPassword,
+        newPassword: payload.newEncryptedPassword,
+        newSalt: payload.newEncryptedSalt,
+        mnemonic: payload.encryptedMnemonic,
+        privateKey: payload.encryptedPrivateKey,
+      },
+      this.headers(),
+    );
+  }
+
+  /**
+   * Updates the authentication credentials and invalidates previous tokens (New backend (drive-server-wip))
+   * @param payload
+   *
+   * @returns {Promise<{token: string, newToken: string}>} A promise that returns new tokens for this user.
+   */
+  public changePassword(payload: ChangePasswordPayloadNew): Promise<{ token: string; newToken: string }> {
     return this.client.patch(
       '/users/password',
       {

--- a/src/drive/users/types.ts
+++ b/src/drive/users/types.ts
@@ -13,6 +13,14 @@ export interface ChangePasswordPayload {
   newEncryptedSalt: string;
   encryptedMnemonic: string;
   encryptedPrivateKey: string;
+}
+
+export interface ChangePasswordPayloadNew {
+  currentEncryptedPassword: string;
+  newEncryptedPassword: string;
+  newEncryptedSalt: string;
+  encryptedMnemonic: string;
+  encryptedPrivateKey: string;
   encryptVersion: string;
 }
 
@@ -26,7 +34,6 @@ export type PreCreateUserResponse = {
 export type FriendInvite = { guestEmail: string; host: number; accepted: boolean; id: number };
 
 export type UserPublicKeyResponse = { publicKey: string };
-
 
 export type VerifyEmailChangeResponse = {
   oldEmail: string;

--- a/src/drive/users/types.ts
+++ b/src/drive/users/types.ts
@@ -13,6 +13,7 @@ export interface ChangePasswordPayload {
   newEncryptedSalt: string;
   encryptedMnemonic: string;
   encryptedPrivateKey: string;
+  encryptVersion: string;
 }
 
 export type UpdateProfilePayload = Partial<Pick<UserSettings, 'name' | 'lastname'>>;

--- a/test/drive/users/index.test.ts
+++ b/test/drive/users/index.test.ts
@@ -112,13 +112,14 @@ describe('# users service tests', () => {
 
       // Assert
       expect(callStub.firstCall.args).toEqual([
-        '/user/password',
+        '/users/password',
         {
           currentPassword: payload.currentEncryptedPassword,
           newPassword: payload.newEncryptedPassword,
           newSalt: payload.newEncryptedSalt,
           mnemonic: payload.encryptedMnemonic,
           privateKey: payload.encryptedPrivateKey,
+          encryptVersion: payload.encryptVersion,
         },
         headers,
       ]);

--- a/test/drive/users/index.test.ts
+++ b/test/drive/users/index.test.ts
@@ -104,6 +104,7 @@ describe('# users service tests', () => {
         encryptedPrivateKey: '3',
         newEncryptedPassword: '4',
         newEncryptedSalt: '5',
+        encryptVersion: '6',
       };
 
       // Act

--- a/test/drive/users/index.test.ts
+++ b/test/drive/users/index.test.ts
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 import { Users } from '../../../src/drive';
-import { headersWithToken } from '../../../src/shared/headers';
-import { ChangePasswordPayload } from '../../../src/drive/users/types';
+import { ChangePasswordPayloadNew } from '../../../src/drive/users/types';
 import { ApiSecurity, AppDetails } from '../../../src/shared';
+import { headersWithToken } from '../../../src/shared/headers';
 import { HttpClient } from '../../../src/shared/http/client';
 
 const httpClient = HttpClient.create('');
@@ -100,7 +100,7 @@ describe('# users service tests', () => {
       const email = 'test@test.com';
       const callStub = sinon.stub(httpClient, 'post').resolves({
         publicKey: 'publicKey',
-        user: { uuid: 'exampleUuid', email }
+        user: { uuid: 'exampleUuid', email },
       });
 
       // Act
@@ -110,7 +110,7 @@ describe('# users service tests', () => {
       expect(callStub.firstCall.args).toEqual(['/users/pre-create', { email }, headers]);
       expect(body).toEqual({
         publicKey: 'publicKey',
-        user: { uuid: 'exampleUuid', email }
+        user: { uuid: 'exampleUuid', email },
       });
     });
   });
@@ -120,7 +120,7 @@ describe('# users service tests', () => {
       // Arrange
       const { client, headers } = clientAndHeaders();
       const callStub = sinon.stub(httpClient, 'patch').resolves({});
-      const payload: ChangePasswordPayload = {
+      const payload: ChangePasswordPayloadNew = {
         currentEncryptedPassword: '1',
         encryptedMnemonic: '2',
         encryptedPrivateKey: '3',


### PR DESCRIPTION
Details:
- We need to migrate server wip endpoint , so this endpoint is named 'users' 
- Also in /users/password the encryptVersion field is required in payload from backend server-wip 

Updates:
- Changed old endpoint `changePassword` as `changePasswordLegacy`
- Added new `changePassword` call to new endpoint
- Added `encryptVersion` in payload