### PR TITLE
[PB-115]: fix/throw error with code instead of only message on user login

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.4.64",
+  "version": "1.4.65",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -4,7 +4,6 @@ import {
   Keys,
   LoginDetails,
   RegisterDetails,
-  UserAccessError,
   SecurityDetails,
   TwoFactorAuthQR,
   RegisterPreCreatedUser,
@@ -159,9 +158,6 @@ export class Auth {
         // @ts-ignore
         data.user.revocationKey = data.user.revocateKey; // TODO : remove when all projects use SDK
         return data;
-      })
-      .catch((error) => {
-        throw new UserAccessError(error.message);
       });
   }
 


### PR DESCRIPTION
For the auto unblock account feature, we need to distinguish between codes thrown by the backend. This is currently preventing us from knowing error codes.