### PR TITLE
[PB-2222, PB-2115] feat: update subscriptions payment methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.4.86",
+  "version": "1.4.87",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/payments/index.ts
+++ b/src/drive/payments/index.ts
@@ -10,6 +10,7 @@ import {
   UserSubscription,
   FreeTrialAvailable,
   RedeemCodePayload,
+  UpdateSubscriptionPaymentMethod,
 } from './types';
 import { HttpClient } from '../../shared/http/client';
 import AppError from '../../shared/types/errors';
@@ -108,6 +109,10 @@ export class Payments {
   public applyRedeemCode(payload: RedeemCodePayload): Promise<void> {
     return this.client.post('/licenses', { code: payload.code, provider: payload.provider }, this.headers());
   }
+
+  public updateSubscriptionPaymentMethod(payload: UpdateSubscriptionPaymentMethod): Promise<void | Error> {
+    return this.client.post('/subscriptions/update-payment-method', { ...payload }, this.headers());
+  };
 
   public updateSubscriptionPrice(
     priceId: string,

--- a/src/drive/payments/index.ts
+++ b/src/drive/payments/index.ts
@@ -11,6 +11,7 @@ import {
   FreeTrialAvailable,
   RedeemCodePayload,
   UpdateSubscriptionPaymentMethod,
+  SubscriptionType,
 } from './types';
 import { HttpClient } from '../../shared/http/client';
 import AppError from '../../shared/types/errors';
@@ -62,7 +63,7 @@ export class Payments {
     return this.client.get('/setup-intent', this.headers());
   }
 
-  public getDefaultPaymentMethod(subscriptionType?: 'individual' | 'business'): Promise<PaymentMethod> {
+  public getDefaultPaymentMethod(subscriptionType?: SubscriptionType): Promise<PaymentMethod> {
     const query = new URLSearchParams();
     if (subscriptionType) query.set('subscriptionType', subscriptionType);
     return this.client.get(`/default-payment-method?${query.toString()}`, this.headers());
@@ -85,7 +86,7 @@ export class Payments {
     return this.client.get(`/coupon-in-use?${query.toString()}`, this.headers());
   }
 
-  public getUserSubscription(subscriptionType?: 'individual' | 'business'): Promise<UserSubscription> {
+  public getUserSubscription(subscriptionType?: SubscriptionType): Promise<UserSubscription> {
     const query = new URLSearchParams();
     if (subscriptionType) query.set('subscriptionType', subscriptionType);
     return this.client.get<UserSubscription>(`/subscriptions?${query.toString()}`, this.headers()).catch((err) => {
@@ -96,7 +97,7 @@ export class Payments {
     });
   }
 
-  public async getPrices(currency?: string, subscriptionType?: 'individual' | 'business'): Promise<DisplayPrice[]> {
+  public async getPrices(currency?: string, subscriptionType?: SubscriptionType): Promise<DisplayPrice[]> {
     const query = new URLSearchParams();
     if (currency !== undefined) query.set('currency', currency);
     if (subscriptionType) query.set('subscriptionType', subscriptionType);
@@ -126,7 +127,7 @@ export class Payments {
     return this.client.put('/subscriptions', { price_id: priceId, couponCode: couponCode }, this.headers());
   }
 
-  public cancelSubscription(subscriptionType?: 'individual' | 'business'): Promise<void> {
+  public cancelSubscription(subscriptionType?: SubscriptionType): Promise<void> {
     const query = new URLSearchParams();
     if (subscriptionType) query.set('subscriptionType', subscriptionType);
     return this.client.delete(`/subscriptions?${query.toString()}`, this.headers());

--- a/src/drive/payments/index.ts
+++ b/src/drive/payments/index.ts
@@ -62,8 +62,10 @@ export class Payments {
     return this.client.get('/setup-intent', this.headers());
   }
 
-  public getDefaultPaymentMethod(): Promise<PaymentMethod> {
-    return this.client.get('/default-payment-method', this.headers());
+  public getDefaultPaymentMethod(subscriptionType?: 'individual' | 'business'): Promise<PaymentMethod> {
+    const query = new URLSearchParams();
+    if (subscriptionType) query.set('subscriptionType', subscriptionType);
+    return this.client.get(`/default-payment-method?${query.toString()}`, this.headers());
   }
 
   public getInvoices({ startingAfter, limit }: { startingAfter?: string; limit?: number }): Promise<Invoice[]> {
@@ -83,8 +85,10 @@ export class Payments {
     return this.client.get(`/coupon-in-use?${query.toString()}`, this.headers());
   }
 
-  public getUserSubscription(): Promise<UserSubscription> {
-    return this.client.get<UserSubscription>('/subscriptions', this.headers()).catch((err) => {
+  public getUserSubscription(subscriptionType?: 'individual' | 'business'): Promise<UserSubscription> {
+    const query = new URLSearchParams();
+    if (subscriptionType) query.set('subscriptionType', subscriptionType);
+    return this.client.get<UserSubscription>(`/subscriptions?${query.toString()}`, this.headers()).catch((err) => {
       const error = err as AppError;
 
       if (error.status === 404) return { type: 'free' };
@@ -92,9 +96,10 @@ export class Payments {
     });
   }
 
-  public async getPrices(currency?: string): Promise<DisplayPrice[]> {
+  public async getPrices(currency?: string, subscriptionType?: 'individual' | 'business'): Promise<DisplayPrice[]> {
     const query = new URLSearchParams();
     if (currency !== undefined) query.set('currency', currency);
+    if (subscriptionType) query.set('subscriptionType', subscriptionType);
     return this.client.get<DisplayPrice[]>(`/prices?${query.toString()}`, this.headers());
   }
 
@@ -112,7 +117,7 @@ export class Payments {
 
   public updateSubscriptionPaymentMethod(payload: UpdateSubscriptionPaymentMethod): Promise<void | Error> {
     return this.client.post('/subscriptions/update-payment-method', { ...payload }, this.headers());
-  };
+  }
 
   public updateSubscriptionPrice(
     priceId: string,
@@ -121,8 +126,10 @@ export class Payments {
     return this.client.put('/subscriptions', { price_id: priceId, couponCode: couponCode }, this.headers());
   }
 
-  public cancelSubscription(): Promise<void> {
-    return this.client.delete('/subscriptions', this.headers());
+  public cancelSubscription(subscriptionType?: 'individual' | 'business'): Promise<void> {
+    const query = new URLSearchParams();
+    if (subscriptionType) query.set('subscriptionType', subscriptionType);
+    return this.client.delete(`/subscriptions?${query.toString()}`, this.headers());
   }
 
   public createCheckoutSession(payload: CreateCheckoutSessionPayload): Promise<{ sessionId: string }> {

--- a/src/drive/payments/types.ts
+++ b/src/drive/payments/types.ts
@@ -100,6 +100,8 @@ export type UserSubscription =
       interval: 'year' | 'month';
       nextPayment: number;
       priceId: string;
+      subscriptionType: 'individual' | 'business';
+      planId?: string;
     };
 
 export interface DisplayPrice {
@@ -130,6 +132,6 @@ export interface RedeemCodePayload {
 }
 
 export interface UpdateSubscriptionPaymentMethod {
-  subscriptionType: string;
+  subscriptionType: 'individual' | 'business';
   paymentMethodId: string;
 }

--- a/src/drive/payments/types.ts
+++ b/src/drive/payments/types.ts
@@ -128,3 +128,8 @@ export interface RedeemCodePayload {
   code: string;
   provider: string;
 }
+
+export interface UpdateSubscriptionPaymentMethod {
+  subscriptionType: string;
+  paymentMethodId: string;
+}

--- a/src/drive/payments/types.ts
+++ b/src/drive/payments/types.ts
@@ -63,6 +63,8 @@ export enum ProductPriceType {
   OneTime = 'one_time',
 }
 
+export type SubscriptionType = 'individual' | 'business';
+
 export interface CreatePaymentSessionPayload {
   test?: boolean;
   lifetime_tier?: LifetimeTier;
@@ -100,7 +102,7 @@ export type UserSubscription =
       interval: 'year' | 'month';
       nextPayment: number;
       priceId: string;
-      subscriptionType: 'individual' | 'business';
+      subscriptionType: SubscriptionType;
       planId?: string;
     };
 
@@ -132,6 +134,6 @@ export interface RedeemCodePayload {
 }
 
 export interface UpdateSubscriptionPaymentMethod {
-  subscriptionType: 'individual' | 'business';
+  subscriptionType: SubscriptionType;
   paymentMethodId: string;
 }

--- a/test/drive/storage/index.test.ts
+++ b/test/drive/storage/index.test.ts
@@ -222,6 +222,7 @@ describe('# storage service tests', () => {
           id: 2,
           name: 'zero',
           plain_name: 'ma-fol',
+          parentUuid: v4(),
           parentId: 0,
           updatedAt: '',
           userId: 1,

--- a/test/drive/storage/mothers/folderContentResponse.mother.ts
+++ b/test/drive/storage/mothers/folderContentResponse.mother.ts
@@ -1,4 +1,11 @@
-import { DriveFileData, FetchFolderContentResponse, FetchPaginatedFilesContent, FetchPaginatedFoldersContent, FileStatus, FolderChild } from '../../../../src/drive/storage/types';
+import {
+  DriveFileData,
+  FetchFolderContentResponse,
+  FetchPaginatedFilesContent,
+  FetchPaginatedFoldersContent,
+  FileStatus,
+  FolderChild,
+} from '../../../../src/drive/storage/types';
 
 export function emptyFolderContentResponse() {
   const response: FetchFolderContentResponse = {
@@ -49,6 +56,7 @@ export function randomFolderContentResponse(folderCount: number, fileCount: numb
     deletedAt: null,
     encrypt_version: '',
     fileId: '',
+    folderUuid: '',
     folderId: 0,
     folder_id: 0,
     id: 0,


### PR DESCRIPTION
## Updates
- Enable a new call to update the payment method for subscriptions.
- Update methods to receive a `subscriptionType` (`business` and `individual`)
- TEST: Storage test repair (add missing fields)


#### PR Related
- Payments: https://github.com/internxt/payments/pull/66
- Use Case in drive-web: https://github.com/internxt/drive-web/pull/1151