### PR TITLE
[PB-2115] Chore: setup-intent could receive a subscriptionType

### DIFF
--- a/src/drive/payments/index.ts
+++ b/src/drive/payments/index.ts
@@ -10,7 +10,6 @@ import {
   UserSubscription,
   FreeTrialAvailable,
   RedeemCodePayload,
-  UpdateSubscriptionPaymentMethod,
   SubscriptionType,
 } from './types';
 import { HttpClient } from '../../shared/http/client';
@@ -116,10 +115,6 @@ export class Payments {
 
   public applyRedeemCode(payload: RedeemCodePayload): Promise<void> {
     return this.client.post('/licenses', { code: payload.code, provider: payload.provider }, this.headers());
-  }
-
-  public updateSubscriptionPaymentMethod(payload: UpdateSubscriptionPaymentMethod): Promise<void | Error> {
-    return this.client.post('/subscriptions/update-payment-method', { ...payload }, this.headers());
   }
 
   public updateSubscriptionPrice(

--- a/src/drive/payments/index.ts
+++ b/src/drive/payments/index.ts
@@ -59,8 +59,10 @@ export class Payments {
     );
   }
 
-  public getSetupIntent(): Promise<{ clientSecret: string }> {
-    return this.client.get('/setup-intent', this.headers());
+  public getSetupIntent(subscriptionType?: SubscriptionType): Promise<{ clientSecret: string }> {
+    const query = new URLSearchParams();
+    if (subscriptionType) query.set('subscriptionType', subscriptionType);
+    return this.client.get(`/setup-intent?${query.toString()}`, this.headers());
   }
 
   public getDefaultPaymentMethod(subscriptionType?: SubscriptionType): Promise<PaymentMethod> {

--- a/src/drive/payments/types.ts
+++ b/src/drive/payments/types.ts
@@ -132,8 +132,3 @@ export interface RedeemCodePayload {
   code: string;
   provider: string;
 }
-
-export interface UpdateSubscriptionPaymentMethod {
-  subscriptionType: SubscriptionType;
-  paymentMethodId: string;
-}


### PR DESCRIPTION
## Updates
- Edit `getSetupIntent` to receive a `subscriptionType`.
- Remove everything related to `updateSubscriptionPaymentMethod`, this will not be necessary. With the modification in `getSetupIntent` we will be able to update the payment method within each subscription.

## Related to
- Payments: https://github.com/internxt/payments/pull/68