### PR TITLE
[PB-2424] Feat: allow folder ancestors shared

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -603,8 +603,9 @@ export class Storage {
   /**
    * Gets the ancestors of a given folder UUID
    *
-   * @param {string} folderUUID - UUID of the folder.
-   * @returns {Promise<FolderAncestor[]>}
+   * @param {string} uuid - UUID of the folder.
+   * @param {boolean} [isShared=false] - Whether the folder is a shared item or not.
+   * @returns {Promise<FolderAncestor[]>} A promise that resolves with an array of ancestors of the given folder.
    */
   public getFolderAncestors(uuid: string, isShared = false): Promise<FolderAncestor[]> {
     return this.client.get<FolderAncestor[]>(`folders/${uuid}/ancestors?isSharedItem=${isShared}`, this.headers());

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -607,7 +607,7 @@ export class Storage {
    * @param {string} folderUUID - UUID of the folder.
    * @returns {Promise<FolderAncestor[]>}
    */
-  public getFolderAncestors(uuid: string, isShared: boolean = false): Promise<FolderAncestor[]> {
+  public getFolderAncestors(uuid: string, isShared = false): Promise<FolderAncestor[]> {
     return this.client.get<FolderAncestor[]>(`folders/${uuid}/ancestors?isSharedItem=${isShared}`, this.headers());
   }
 

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -607,8 +607,8 @@ export class Storage {
    * @param {string} folderUUID - UUID of the folder.
    * @returns {Promise<FolderAncestor[]>}
    */
-  public getFolderAncestors(uuid: string): Promise<FolderAncestor[]> {
-    return this.client.get<FolderAncestor[]>(`folders/${uuid}/ancestors`, this.headers());
+  public getFolderAncestors(uuid: string, isShared: boolean = false): Promise<FolderAncestor[]> {
+    return this.client.get<FolderAncestor[]>(`folders/${uuid}/ancestors?isSharedItem=${isShared}`, this.headers());
   }
 
   /**


### PR DESCRIPTION
### Update
- Add `isSharedItem` in the request to non-block the details of the files/folders.


### Related to
- wip: https://github.com/internxt/drive-server-wip/pull/399
- web : https://github.com/internxt/drive-web/pull/1290