### PR TITLE
[PB-2985]: feat/fetch the workspace folder ancestor without the root workspace folder and root member folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.5.20",
+  "version": "1.5.21",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -605,10 +605,15 @@ export class Storage {
    *
    * @param {string} uuid - UUID of the folder.
    * @param {boolean} [isShared=false] - Whether the folder is a shared item or not.
+   * @param {boolean} [workspace=false] - Wether the folder is a workspace folder or not
    * @returns {Promise<FolderAncestor[]>} A promise that resolves with an array of ancestors of the given folder.
    */
-  public getFolderAncestors(uuid: string, isShared = false): Promise<FolderAncestor[]> {
-    return this.client.get<FolderAncestor[]>(`folders/${uuid}/ancestors?isSharedItem=${isShared}`, this.headers());
+  public getFolderAncestors(uuid: string, workspace = false, isShared = false): Promise<FolderAncestor[]> {
+    const queryParams = new URLSearchParams();
+    queryParams.set('workspace', String(workspace));
+    queryParams.set('isSharedItem', String(isShared));
+
+    return this.client.get<FolderAncestor[]>(`folders/${uuid}/ancestors?${queryParams}?${queryParams}`, this.headers());
   }
 
   /**

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -622,7 +622,7 @@ export class Storage {
     queryParams.set('workspace', String(workspace));
     queryParams.set('isSharedItem', String(isShared));
 
-    return this.client.get<FolderAncestor[]>(`folders/${uuid}/ancestors?${queryParams}?${queryParams}`, this.headers());
+    return this.client.get<FolderAncestor[]>(`folders/${uuid}/ancestors?${queryParams}`, this.headers());
   }
 
   /**

--- a/test/drive/storage/index.test.ts
+++ b/test/drive/storage/index.test.ts
@@ -209,6 +209,72 @@ describe('# storage service tests', () => {
       });
     });
 
+    describe('get ancestors from an item', () => {
+      const ROOT_FOLDER_UUID = '12345';
+      const IS_WORKSPACE = true;
+      const IS_SHARED = true;
+
+      it('Should call with correct params for a personal space', async () => {
+        // Arrange
+        const queryParams = new URLSearchParams();
+        queryParams.set('workspace', String(!IS_WORKSPACE));
+        queryParams.set('isSharedItem', String(!IS_SHARED));
+        const { folders } = randomSubfoldersResponse(2);
+        const { client, headers } = clientAndHeaders();
+        const callStub = sinon.stub(httpClient, 'get').returns(Promise.resolve(folders));
+
+        // Act
+        const body = await client.getFolderAncestors(ROOT_FOLDER_UUID);
+
+        // Assert
+        expect(callStub.firstCall.args).toEqual([
+          `folders/${ROOT_FOLDER_UUID}/ancestors?${queryParams.toString()}`,
+          headers,
+        ]);
+        expect(body).toHaveLength(2);
+      });
+
+      it('Should call with correct params for a workspace', async () => {
+        // Arrange
+        const queryParams = new URLSearchParams();
+        queryParams.set('workspace', String(IS_WORKSPACE));
+        queryParams.set('isSharedItem', String(!IS_SHARED));
+        const { folders } = randomSubfoldersResponse(2);
+        const { client, headers } = clientAndHeaders();
+        const callStub = sinon.stub(httpClient, 'get').returns(Promise.resolve(folders));
+
+        // Act
+        const body = await client.getFolderAncestors(ROOT_FOLDER_UUID, IS_WORKSPACE);
+
+        // Assert
+        expect(callStub.firstCall.args).toEqual([
+          `folders/${ROOT_FOLDER_UUID}/ancestors?${queryParams.toString()}`,
+          headers,
+        ]);
+        expect(body).toHaveLength(2);
+      });
+
+      it('Should call with correct params for a shared item', async () => {
+        // Arrange
+        const queryParams = new URLSearchParams();
+        queryParams.set('workspace', String(IS_WORKSPACE));
+        queryParams.set('isSharedItem', String(IS_SHARED));
+        const { folders } = randomSubfoldersResponse(2);
+        const { client, headers } = clientAndHeaders();
+        const callStub = sinon.stub(httpClient, 'get').returns(Promise.resolve(folders));
+
+        // Act
+        const body = await client.getFolderAncestors(ROOT_FOLDER_UUID, IS_WORKSPACE, IS_SHARED);
+
+        // Assert
+        expect(callStub.firstCall.args).toEqual([
+          `folders/${ROOT_FOLDER_UUID}/ancestors?${queryParams.toString()}`,
+          headers,
+        ]);
+        expect(body).toHaveLength(2);
+      });
+    });
+
     describe('create folder entry', () => {
       it('Should call with correct params & return content', async () => {
         // Arrange
@@ -666,7 +732,7 @@ describe('# storage service tests', () => {
   });
 });
 
-function clientAndHeaders(
+export function clientAndHeaders(
   apiUrl = '',
   clientName = 'c-name',
   clientVersion = '0.1',


### PR DESCRIPTION
- Pass a parameter called `isWorkspace` to obtain the ancestors of an item in the workspace excluding the root folder level of the workspace and the root of the member