### PR TITLE
[PB-2979]: feat/migrate recents endpoint to the new API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.5.19",
+  "version": "1.5.21",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.5.21",
+  "version": "1.5.20",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -519,8 +519,17 @@ export class Storage {
   /**
    * Returns a list of the n most recent files
    * @param limit
+   * @deprecated use `getRecentFilesV2` call instead.
    */
-  public async getRecentFiles(limit: number): Promise<DriveFileData[]> {
+  public getRecentFiles(limit: number): Promise<DriveFileData[]> {
+    return this.client.get(`/storage/recents?limit=${limit}`, this.headers());
+  }
+
+  /**
+   * Returns a list of the n most recent files
+   * @param limit
+   */
+  public async getRecentFilesV2(limit: number): Promise<DriveFileData[]> {
     return this.client.get<DriveFileData[]>(`/files/recents?limit=${limit}`, this.headers());
   }
 

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -520,8 +520,8 @@ export class Storage {
    * Returns a list of the n most recent files
    * @param limit
    */
-  public getRecentFiles(limit: number): Promise<DriveFileData[]> {
-    return this.client.get(`/storage/recents?limit=${limit}`, this.headers());
+  public async getRecentFiles(limit: number): Promise<DriveFileData[]> {
+    return this.client.get<DriveFileData[]>(`/files/recents?limit=${limit}`, this.headers());
   }
 
   /**

--- a/test/drive/storage/index.test.ts
+++ b/test/drive/storage/index.test.ts
@@ -515,7 +515,7 @@ describe('# storage service tests', () => {
         const body = await client.getRecentFiles(5);
 
         // Assert
-        expect(callStub.firstCall.args).toEqual(['/storage/recents?limit=5', headers]);
+        expect(callStub.firstCall.args).toEqual(['/files/recents?limit=5', headers]);
         expect(body).toEqual({
           files: [],
         });

--- a/test/drive/storage/index.test.ts
+++ b/test/drive/storage/index.test.ts
@@ -515,6 +515,25 @@ describe('# storage service tests', () => {
         const body = await client.getRecentFiles(5);
 
         // Assert
+        expect(callStub.firstCall.args).toEqual(['/storage/recents?limit=5', headers]);
+        expect(body).toEqual({
+          files: [],
+        });
+      });
+    });
+
+    describe('get recent files V2', () => {
+      it('Should be called with right arguments & return content', async () => {
+        // Arrange
+        const callStub = sinon.stub(httpClient, 'get').resolves({
+          files: [],
+        });
+        const { client, headers } = clientAndHeaders();
+
+        // Act
+        const body = await client.getRecentFilesV2(5);
+
+        // Assert
         expect(callStub.firstCall.args).toEqual(['/files/recents?limit=5', headers]);
         expect(body).toEqual({
           files: [],


### PR DESCRIPTION
- Migrating the Recents endpoint to the new API.