### PR TITLE
[PB-2345]: fix/mark space limit as optional when inviting a member to workspace and modify the existent member usage 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.5.21",
+  "version": "1.5.22",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/workspaces/index.test.ts
+++ b/src/workspaces/index.test.ts
@@ -192,6 +192,26 @@ describe('Workspaces service tests', () => {
       });
     });
 
+    describe('getWorkspaceUsage', () => {
+      it('should return workspace usage when getWorkspaceUsage is called', async () => {
+        const { client, headers } = clientAndHeaders();
+        const workspaceId = 'workspaceId';
+
+        const usageResponse = {
+          totalWorkspaceSpace: 1024 * 1024 * 1024 * 2,
+          spaceAssigned: 1024 * 1024 * 1024 * 1.5,
+          spaceUsed: 1024 * 1024 * 1024 * 1,
+        };
+
+        const getCall = sinon.stub(httpClient, 'get').resolves(usageResponse);
+
+        const response = await client.getWorkspaceUsage(workspaceId);
+
+        expect(getCall.firstCall.args).toEqual([`workspaces/${workspaceId}/usage`, headers]);
+        expect(response).toEqual(usageResponse);
+      });
+    });
+
     describe('getWorkspacesTeams', () => {
       it('should return the teams of a workspace when getWorkspacesTeams is called', async () => {
         const workspaceId = 'workspaceId';
@@ -388,6 +408,40 @@ describe('Workspaces service tests', () => {
           },
           headers,
         ]);
+      });
+    });
+
+    describe('modifyMemberUsage', () => {
+      it('should modify the member usage limit successfully', async () => {
+        const { client, headers } = clientAndHeaders();
+        const workspaceId = 'workspaceId';
+        const memberId = 'memberId';
+        const spaceLimitBytes = 1024 * 1024 * 1024;
+
+        const workspaceUserResponse = {
+          id: 'memberId',
+          spaceLimit: '1GB',
+          driveUsage: '500MB',
+          backupsUsage: '200MB',
+          deactivated: false,
+          member: {
+            id: 1,
+            name: 'MemberName',
+            lastname: 'MemberLastName',
+            email: 'email@email.com',
+          },
+        };
+
+        const patchCall = sinon.stub(httpClient, 'patch').resolves(workspaceUserResponse);
+
+        const response = await client.modifyMemberUsage(workspaceId, memberId, spaceLimitBytes);
+
+        expect(patchCall.firstCall.args).toEqual([
+          `workspaces/${workspaceId}/members/${memberId}/usage`,
+          { spaceLimit: spaceLimitBytes },
+          headers,
+        ]);
+        expect(response).toEqual(workspaceUserResponse);
       });
     });
 

--- a/src/workspaces/index.test.ts
+++ b/src/workspaces/index.test.ts
@@ -370,7 +370,7 @@ describe('Workspaces service tests', () => {
         await client.changeUserRole(teamId, memberId, role);
 
         expect(patchCall.firstCall.args).toEqual([
-          `/api/workspaces/{workspaceId}/teams/${teamId}/members/${memberId}/role`,
+          `/api/workspaces/teams/${teamId}/members/${memberId}/role`,
           { role },
           headers,
         ]);

--- a/src/workspaces/index.ts
+++ b/src/workspaces/index.ts
@@ -28,6 +28,7 @@ import {
   WorkspacesResponse,
   WorkspaceTeamResponse,
   TeamMembers,
+  WorkspaceUser,
 } from './types';
 
 export class Workspaces {
@@ -123,6 +124,12 @@ export class Workspaces {
     );
   }
 
+  public getWorkspaceUsage(
+    workspaceId: string,
+  ): Promise<{ totalWorkspaceSpace: number; spaceAssigned: number; spaceUsed: number }> {
+    return this.client.get(`workspaces/${workspaceId}/usage`, this.headers());
+  }
+
   public editWorkspace(
     workspaceId: string,
     details: { name?: string; description?: string; address?: string },
@@ -213,7 +220,7 @@ export class Workspaces {
 
   public changeUserRole(teamId: string, memberId: string, role: string): Promise<void> {
     return this.client.patch<void>(
-      `/api/workspaces/{workspaceId}/teams/${teamId}/members/${memberId}/role`,
+      `/api/workspaces/teams/${teamId}/members/${memberId}/role`,
       {
         role,
       },
@@ -248,6 +255,10 @@ export class Workspaces {
 
   public getMemberDetails(workspaceId: string, memberId: string): Promise<GetMemberDetailsResponse> {
     return this.client.get<GetMemberDetailsResponse>(`workspaces/${workspaceId}/members/${memberId}`, this.headers());
+  }
+
+  public changeMemberAssignedSpace(workspaceId: string, memberId: string): Promise<WorkspaceUser> {
+    return this.client.patch<WorkspaceUser>(`workspaces/${workspaceId}/members/${memberId}/usage`, {}, this.headers());
   }
 
   public getMemberUsage(workspaceId: string): Promise<GetMemberUsageResponse> {

--- a/src/workspaces/index.ts
+++ b/src/workspaces/index.ts
@@ -257,8 +257,14 @@ export class Workspaces {
     return this.client.get<GetMemberDetailsResponse>(`workspaces/${workspaceId}/members/${memberId}`, this.headers());
   }
 
-  public changeMemberAssignedSpace(workspaceId: string, memberId: string): Promise<WorkspaceUser> {
-    return this.client.patch<WorkspaceUser>(`workspaces/${workspaceId}/members/${memberId}/usage`, {}, this.headers());
+  public modifyMemberUsage(workspaceId: string, memberId: string, spaceLimitBytes: number): Promise<WorkspaceUser> {
+    return this.client.patch<WorkspaceUser>(
+      `workspaces/${workspaceId}/members/${memberId}/usage`,
+      {
+        spaceLimit: spaceLimitBytes,
+      },
+      this.headers(),
+    );
   }
 
   public getMemberUsage(workspaceId: string): Promise<GetMemberUsageResponse> {

--- a/src/workspaces/index.ts
+++ b/src/workspaces/index.ts
@@ -29,6 +29,7 @@ import {
   WorkspaceTeamResponse,
   TeamMembers,
   WorkspaceUser,
+  WorkspaceUsage,
 } from './types';
 
 export class Workspaces {
@@ -124,10 +125,8 @@ export class Workspaces {
     );
   }
 
-  public getWorkspaceUsage(
-    workspaceId: string,
-  ): Promise<{ totalWorkspaceSpace: number; spaceAssigned: number; spaceUsed: number }> {
-    return this.client.get(`workspaces/${workspaceId}/usage`, this.headers());
+  public getWorkspaceUsage(workspaceId: string): Promise<WorkspaceUsage> {
+    return this.client.get<WorkspaceUsage>(`workspaces/${workspaceId}/usage`, this.headers());
   }
 
   public editWorkspace(

--- a/src/workspaces/types.ts
+++ b/src/workspaces/types.ts
@@ -150,7 +150,7 @@ export type WorkspaceTeamResponse = WorkspaceTeam[];
 export type InviteMemberBody = {
   workspaceId: string;
   invitedUserEmail: string;
-  spaceLimitBytes: number;
+  spaceLimitBytes?: number;
   encryptedMnemonicInBase64: string;
   encryptionAlgorithm: string;
   message: string;

--- a/src/workspaces/types.ts
+++ b/src/workspaces/types.ts
@@ -40,6 +40,12 @@ export interface WorkspaceData {
   workspace: Workspace;
 }
 
+export interface WorkspaceUsage {
+  totalWorkspaceSpace: number;
+  spaceAssigned: number;
+  spaceUsed: number;
+}
+
 export type WorkspaceSetupInfo = {
   workspaceId: string;
   name: string;


### PR DESCRIPTION
- Mark the spaceLimit parameter as optional when inviting a user.
- Allow the owner to modify the storage of an existent member.
- Get the workspace usage info (totalWorkspaceSpace, spaceAssigned, spaceUsed).