### PR TITLE
[PB-2981]: feat/[B2B – Drive] - fuzzy search for b2b items

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,8 @@
 {
   "extends": "@internxt/eslint-config-internxt",
-  "ignorePatterns": "dist"
+  "ignorePatterns": "dist",
+  "rules": {
+    "linebreak-style": "off",
+    "@typescript-eslint/no-explicit-any": "off"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/sdk",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -584,13 +584,13 @@ export class Storage {
    * Get global search items.
    *
    * @param {string} search - The name of the item.
+   * @param {string} workspaceId - The ID of the workspace (optional).
    * @returns {[Promise<SearchResultData>, RequestCanceler]} An array containing a promise to get the API response and a function to cancel the request.
    */
-  public getGlobalSearchItems(search: string): [Promise<SearchResultData>, RequestCanceler] {
-    const { promise, requestCanceler } = this.client.getCancellable<SearchResultData>(
-      `fuzzy/${search}`,
-      this.headers(),
-    );
+  public getGlobalSearchItems(search: string, workspaceId?: string): [Promise<SearchResultData>, RequestCanceler] {
+    const { promise, requestCanceler } = workspaceId
+      ? this.client.getCancellable<SearchResultData>(`${workspaceId}/fuzzy/${search}`, this.headers())
+      : this.client.getCancellable<SearchResultData>(`fuzzy/${search}`, this.headers());
 
     return [promise, requestCanceler];
   }

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -589,7 +589,7 @@ export class Storage {
    */
   public getGlobalSearchItems(search: string, workspaceId?: string): [Promise<SearchResultData>, RequestCanceler] {
     const { promise, requestCanceler } = workspaceId
-      ? this.client.getCancellable<SearchResultData>(`${workspaceId}/fuzzy/${search}`, this.headers())
+      ? this.client.getCancellable<SearchResultData>(`workspaces/${workspaceId}/fuzzy/${search}`, this.headers())
       : this.client.getCancellable<SearchResultData>(`fuzzy/${search}`, this.headers());
 
     return [promise, requestCanceler];


### PR DESCRIPTION
Searching for items in B2B doesn't return any result, instead it shows the items in B2C. When clicking on a result, the app crashes.