### PR TITLE
[PB-2153] feat: do not request the user's password in security endpoints

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -224,9 +224,8 @@ export class Auth {
    * @param pass
    * @param code
    */
-  public disableTwoFactorAuth(pass: string, code: string): Promise<void> {
+  public disableTwoFactorAuth(code: string): Promise<void> {
     return this.client.delete('/tfa', this.headersWithToken(<string>this.apiSecurity?.token), {
-      pass: pass,
       code: code,
     });
   }

--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -125,7 +125,6 @@ export class Users {
     return this.client.patch(
       '/users/password',
       {
-        currentPassword: payload.currentEncryptedPassword,
         newPassword: payload.newEncryptedPassword,
         newSalt: payload.newEncryptedSalt,
         mnemonic: payload.encryptedMnemonic,

--- a/src/drive/users/types.ts
+++ b/src/drive/users/types.ts
@@ -16,7 +16,6 @@ export interface ChangePasswordPayload {
 }
 
 export interface ChangePasswordPayloadNew {
-  currentEncryptedPassword: string;
   newEncryptedPassword: string;
   newEncryptedSalt: string;
   encryptedMnemonic: string;

--- a/test/auth/index.test.ts
+++ b/test/auth/index.test.ts
@@ -386,17 +386,16 @@ describe('# auth service tests', () => {
       // Arrange
       const callStub = sinon.stub(httpClient, 'delete').resolves({});
       const { client, headers } = clientAndHeadersWithToken();
-      const pass = 'pass', code = 'code';
+      const code = 'code';
 
       // Act
-      const body = await client.disableTwoFactorAuth(pass, code);
+      const body = await client.disableTwoFactorAuth(code);
 
       // Assert
       await expect(callStub.firstCall.args).toEqual([
         '/tfa',
         headers,
         {
-          pass: pass,
           code: code,
         }
       ]);

--- a/test/drive/users/index.test.ts
+++ b/test/drive/users/index.test.ts
@@ -121,7 +121,6 @@ describe('# users service tests', () => {
       const { client, headers } = clientAndHeaders();
       const callStub = sinon.stub(httpClient, 'patch').resolves({});
       const payload: ChangePasswordPayloadNew = {
-        currentEncryptedPassword: '1',
         encryptedMnemonic: '2',
         encryptedPrivateKey: '3',
         newEncryptedPassword: '4',
@@ -136,7 +135,6 @@ describe('# users service tests', () => {
       expect(callStub.firstCall.args).toEqual([
         '/users/password',
         {
-          currentPassword: payload.currentEncryptedPassword,
           newPassword: payload.newEncryptedPassword,
           newSalt: payload.newEncryptedSalt,
           mnemonic: payload.encryptedMnemonic,


### PR DESCRIPTION
### Ticket
- https://inxt.atlassian.net/browse/PB-2153

### Updates
- Do not request the user's password to update their password or their TFA (Two Factor Authentication)

### PR related
- wip: https://github.com/internxt/drive-server-wip/pull/423
- server: https://github.com/internxt/drive-server/pull/460
- web: https://github.com/internxt/drive-web/pull/1341