### PR TITLE
[PB-3078] add salt to the upgrade request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -351,15 +351,16 @@ export class Auth {
   }
 
   /**
-   * Upgrade hash in the database
+   * Upgrade hash and salt in the database
    * @param newHash
+   * @param newSalt
    */
-  public upgradeHash(newHash: string): Promise<void> {
+  public upgradeHash(newHash: string, newSalt: string): Promise<void> {
     return this.client.patch(
       '/users/:id',
       {
         newPassword: newHash,
-        newSalt:'',
+        newSalt: newSalt,
       },
       this.basicHeaders(),
     );


### PR DESCRIPTION
Add salt to upgradeHash request

P.S. Argon2 outputs results like this, where salt is already included into the hash `$argon2id$v=19$m=65536,t=2,p=1$gZiV/M1gPc22ElAH/Jh1Hw$CWOrkoo7oJBQ/iyh7uJ0LO2aLEfrHwTWllSAxT0zRno`. However, to keep the same workflow, the salt will be sent to the database along with the hash