### PR TITLE
[PB-3585]: fix/get invoices for each plan type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/payments/index.ts
+++ b/src/drive/payments/index.ts
@@ -123,10 +123,16 @@ export class Payments {
     return this.client.get(`/default-payment-method?${query.toString()}`, this.headers());
   }
 
-  public getInvoices({ subscriptionId, startingAfter, limit }: InvoicePayload): Promise<Invoice[]> {
+  public getInvoices({
+    subscriptionId,
+    userType = UserType.Individual,
+    startingAfter,
+    limit,
+  }: InvoicePayload): Promise<Invoice[]> {
     const query = new URLSearchParams();
-    if (subscriptionId) query.set('subscription', subscriptionId);
+    if (subscriptionId !== undefined) query.set('subscription', subscriptionId);
     if (startingAfter !== undefined) query.set('starting_after', startingAfter);
+    if (userType !== undefined) query.set('userType', userType);
     if (limit !== undefined) query.set('limit', limit.toString());
 
     return this.client.get(`/invoices?${query.toString()}`, this.headers());

--- a/src/drive/payments/types.ts
+++ b/src/drive/payments/types.ts
@@ -138,8 +138,9 @@ export interface Invoice {
 }
 
 export interface InvoicePayload {
-  subscriptionId: string;
+  subscriptionId?: string;
   startingAfter?: string;
+  userType?: UserType;
   limit?: number;
 }
 


### PR DESCRIPTION
Fetch the invoices depending on the userType (`individual` or `business`) to get all invoices the user has, not only for the current subscriptionId if there is any. 

With this change, we can also fetch the lifetime invoices for `UserType.Individual` type.