### PR TITLE
[PB-3627]: Align fields with what backend expects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -62,11 +62,11 @@ export class Auth {
         keys: {
           ecc: {
             publicKey: registerDetails.keys.ecc.publicKey,
-            privateKeyEncrypted: registerDetails.keys.ecc.privateKeyEncrypted,
+            privateKey: registerDetails.keys.ecc.privateKeyEncrypted,
           },
           kyber: {
             publicKey: registerDetails.keys.kyber.publicKey,
-            privateKeyEncrypted: registerDetails.keys.kyber.privateKeyEncrypted,
+            privateKey: registerDetails.keys.kyber.privateKeyEncrypted,
           },
         },
         referral: registerDetails.referral,
@@ -101,11 +101,11 @@ export class Auth {
         keys: {
           ecc: {
             publicKey: registerDetails.keys.ecc.publicKey,
-            privateKeyEncrypted: registerDetails.keys.ecc.privateKeyEncrypted,
+            privateKey: registerDetails.keys.ecc.privateKeyEncrypted,
           },
           kyber: {
             publicKey: registerDetails.keys.kyber.publicKey,
-            privateKeyEncrypted: registerDetails.keys.kyber.privateKeyEncrypted,
+            privateKey: registerDetails.keys.kyber.privateKeyEncrypted,
           },
         },
         referral: registerDetails.referral,
@@ -182,11 +182,11 @@ export class Auth {
           keys: {
             ecc: {
               publicKey: keys.ecc.publicKey,
-              privateKeyEncrypted: keys.ecc.privateKeyEncrypted,
+              privateKey: keys.ecc.privateKeyEncrypted,
             },
             kyber: {
               publicKey: keys.kyber.publicKey,
-              privateKeyEncrypted: keys.kyber.privateKeyEncrypted,
+              privateKey: keys.kyber.privateKeyEncrypted,
             },
           },
         },
@@ -217,11 +217,11 @@ export class Auth {
         revocationKey: keys.revocationCertificate,
         ecc: {
           publicKey: keys.ecc.publicKey,
-          privateKeyEncrypted: keys.ecc.privateKeyEncrypted,
+          privateKey: keys.ecc.privateKeyEncrypted,
         },
         kyber: {
           publicKey: keys.kyber.publicKey,
-          privateKeyEncrypted: keys.kyber.privateKeyEncrypted,
+          privateKey: keys.kyber.privateKeyEncrypted,
         },
       },
       this.headersWithToken(token),

--- a/test/auth/index.test.ts
+++ b/test/auth/index.test.ts
@@ -55,11 +55,11 @@ describe('# auth service tests', () => {
           keys: {
             ecc: {
               publicKey: registerDetails.keys.ecc.publicKey,
-              privateKeyEncrypted: registerDetails.keys.ecc.privateKeyEncrypted,
+              privateKey: registerDetails.keys.ecc.privateKeyEncrypted,
             },
             kyber: {
               publicKey: registerDetails.keys.kyber.publicKey,
-              privateKeyEncrypted: registerDetails.keys.kyber.privateKeyEncrypted,
+              privateKey: registerDetails.keys.kyber.privateKeyEncrypted,
             },
           },
           referral: registerDetails.referral,
@@ -129,11 +129,11 @@ describe('# auth service tests', () => {
           keys: {
             ecc: {
               publicKey: registerDetails.keys.ecc.publicKey,
-              privateKeyEncrypted: registerDetails.keys.ecc.privateKeyEncrypted,   
+              privateKey: registerDetails.keys.ecc.privateKeyEncrypted,   
             },
             kyber: {
               publicKey: registerDetails.keys.kyber.publicKey,
-              privateKeyEncrypted: registerDetails.keys.kyber.privateKeyEncrypted,
+              privateKey: registerDetails.keys.kyber.privateKeyEncrypted,
             },
           },
           referral: registerDetails.referral,
@@ -308,11 +308,11 @@ describe('# auth service tests', () => {
           keys: {
             ecc: {
               publicKey: 'pub',
-              privateKeyEncrypted: 'priv',
+              privateKey: 'priv',
             },
             kyber: {
               publicKey: 'pubKyber',
-              privateKeyEncrypted: 'privKyber',
+              privateKey: 'privKyber',
             },
           },
         },
@@ -359,11 +359,11 @@ describe('# auth service tests', () => {
           revocationKey: 'crt',
           ecc: {
             publicKey: 'pub',
-            privateKeyEncrypted: 'priv',
+            privateKey: 'priv',
           },
           kyber: {
             publicKey: 'pubKyber',
-            privateKeyEncrypted: 'privKyber',
+            privateKey: 'privKyber',
           },
         },
         headers,


### PR DESCRIPTION
The backend expects `privateKey` instead of `privateKeyEncrypted`, so this PR aligns the names