### PR TITLE
[_]: feat/get lifetime product id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/payments/types.ts
+++ b/src/drive/payments/types.ts
@@ -145,7 +145,8 @@ export interface InvoicePayload {
 }
 
 export type UserSubscription =
-  | { type: 'free' | 'lifetime' }
+  | { type: 'free' }
+  | { type: 'lifetime'; productId?: string }
   | {
       type: 'subscription';
       subscriptionId: string;
@@ -155,13 +156,14 @@ export type UserSubscription =
       interval: 'year' | 'month';
       nextPayment: number;
       priceId: string;
+      productId?: string;
       userType?: UserType;
-      planId?: string;
       plan?: StoragePlan;
     };
 
 export interface DisplayPrice {
   id: string;
+  productId?: string;
   bytes: number;
   interval: 'year' | 'month' | 'lifetime';
   amount: number;

--- a/src/drive/payments/types.ts
+++ b/src/drive/payments/types.ts
@@ -210,5 +210,6 @@ export type CreatedSubscriptionData = {
 export type AvailableProducts = {
   featuresPerService: {
     antivirus: boolean;
+    backups: boolean;
   };
 };


### PR DESCRIPTION
This PR introduces a new feature in the Internxt SDK that allows retrieving the lifetime product ID associated with a user.

In addition, we also obtain if the user can use backups depending on the plan the user has.