### PR TITLE
[PB-3702]: feat/recover account with keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -8,6 +8,7 @@ import {
   TwoFactorAuthQR,
   RegisterPreCreatedUser,
   RegisterPreCreatedUserResponse,
+  PrivateKeys,
 } from './types';
 import { UserSettings, UUID } from '../shared/types/userSettings';
 import { TeamsSettings } from '../shared/types/teams';
@@ -389,12 +390,14 @@ export class Auth {
    * @param password
    * @param salt
    * @param mnemonic
+   * @param keys
    */
   public changePasswordWithLink(
     token: string | undefined,
     password: string,
     salt: string,
     mnemonic: string,
+    keys?: PrivateKeys,
   ): Promise<void> {
     return this.client.put(
       `/users/recover-account?token=${token}&reset=false`,
@@ -402,6 +405,7 @@ export class Auth {
         password: password,
         salt: salt,
         mnemonic: mnemonic,
+        privateKeys: keys,
       },
       this.basicHeaders(),
     );

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -67,3 +67,8 @@ export interface BasicAuth {
   username: string;
   password: string;
 }
+
+export interface PrivateKeys {
+  ecc?: string;
+  kyber?: string;
+}

--- a/test/auth/index.test.ts
+++ b/test/auth/index.test.ts
@@ -129,7 +129,7 @@ describe('# auth service tests', () => {
           keys: {
             ecc: {
               publicKey: registerDetails.keys.ecc.publicKey,
-              privateKey: registerDetails.keys.ecc.privateKeyEncrypted,   
+              privateKey: registerDetails.keys.ecc.privateKeyEncrypted,
             },
             kyber: {
               publicKey: registerDetails.keys.kyber.publicKey,
@@ -550,6 +550,56 @@ describe('# auth service tests', () => {
       // Assert
       expect(callStub.firstCall.args).toEqual(['users/unblock-account', { token }, headers]);
       expect(body).toEqual({});
+    });
+  });
+
+  describe('-> change password with link', () => {
+    it('Should call with right params without private keys', async () => {
+      const callStub = sinon.stub(httpClient, 'put').resolves({});
+      const { client, headers } = clientAndHeaders();
+      const token = 'token';
+      const password = 'newPassword';
+      const salt = 'newSalt';
+      const mnemonic = 'newMnemonic';
+
+      await client.changePasswordWithLink(token, password, salt, mnemonic);
+
+      expect(callStub.firstCall.args).toEqual([
+        `/users/recover-account?token=${token}&reset=false`,
+        {
+          password,
+          salt,
+          mnemonic,
+        },
+        headers,
+      ]);
+    });
+
+    it('Should call with right params including private keys', async () => {
+      const callStub = sinon.stub(httpClient, 'put').resolves({});
+      const { client, headers } = clientAndHeaders();
+      const token = 'token';
+      const password = 'newPassword';
+      const salt = 'newSalt';
+      const mnemonic = 'newMnemonic';
+      const privateKeys = {
+        ecc: 'newEccKey',
+        kyber: 'newKyberKey',
+      };
+
+      await client.changePasswordWithLink(token, password, salt, mnemonic, privateKeys);
+
+      // Assert
+      expect(callStub.firstCall.args).toEqual([
+        `/users/recover-account?token=${token}&reset=false`,
+        {
+          password,
+          salt,
+          mnemonic,
+          privateKeys,
+        },
+        headers,
+      ]);
     });
   });
 });


### PR DESCRIPTION
Add support for optionally updating private keys during account recovery. 
server-wip changes: #internxt/drive-server-wip/pull/506