### PR TITLE
[PB-4224]: feat/add additional desktop headers in network constructor

### DIFF
--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -265,10 +265,20 @@ export class Network {
    * @param auth
    */
   private static headersWithBasicAuth(appDetails: AppDetails, auth: BasicAuth) {
-    return headersWithBasicAuth(appDetails.clientName, appDetails.clientVersion, auth);
+    const additionalHeaders = this.mapAdditionalHeaders(appDetails);
+    return headersWithBasicAuth(appDetails.clientName, appDetails.clientVersion, auth, undefined, additionalHeaders);
   }
 
   private static headersWithAuthToken(appDetails: AppDetails, token: string) {
-    return headersWithAuthToken(appDetails.clientName, appDetails.clientVersion, token);
+    const additionalHeaders = this.mapAdditionalHeaders(appDetails);
+    return headersWithAuthToken(appDetails.clientName, appDetails.clientVersion, token, undefined, additionalHeaders);
+  }
+
+  private static mapAdditionalHeaders(appDetails: AppDetails): Record<string, string> {
+    const additionalHeaders: Record<string, string> = {};
+    if (appDetails.desktopHeader) {
+      additionalHeaders['x-internxt-desktop-header'] = appDetails.desktopHeader;
+    }
+    return additionalHeaders;
   }
 }

--- a/src/shared/headers/index.ts
+++ b/src/shared/headers/index.ts
@@ -80,6 +80,7 @@ export function headersWithBasicAuth(
   clientVersion: string,
   auth: BasicAuth,
   workspaceToken?: Token,
+  customHeaders?: CustomHeaders,
 ): InternxtHeaders {
   const headers = basicHeaders(clientName, clientVersion);
   const token = `${auth.username}:${auth.password}`;
@@ -93,6 +94,7 @@ export function headersWithBasicAuth(
   return {
     ...headers,
     ...extra,
+    ...customHeaders,
   };
 }
 
@@ -101,6 +103,7 @@ export function headersWithAuthToken(
   clientVersion: string,
   token: Token,
   workspaceToken?: Token,
+  customHeaders?: CustomHeaders,
 ): InternxtHeaders {
   const headers = basicHeaders(clientName, clientVersion);
   const extra: ExtraHeaders = {};
@@ -112,6 +115,7 @@ export function headersWithAuthToken(
     ...headers,
     'x-token': token,
     ...extra,
+    ...customHeaders,
   };
 }
 

--- a/test/network/network.test.ts
+++ b/test/network/network.test.ts
@@ -7,7 +7,7 @@ import {
   InvalidFileIndexError,
   InvalidUploadIndexError,
   InvalidUploadSizeError,
-  Network
+  Network,
 } from '../../src/network/index';
 import { headersWithBasicAuth } from '../../src/shared/headers/index';
 import {
@@ -269,6 +269,7 @@ function clientAndHeadersWithBasicAuth(
     bridgeUser: 'user',
     userId: 'password',
   },
+  desktopHeader = 'desktop-header',
 ): {
   client: Network;
   headers: object;
@@ -276,11 +277,18 @@ function clientAndHeadersWithBasicAuth(
   const appDetails: AppDetails = {
     clientName: clientName,
     clientVersion: clientVersion,
+    desktopHeader,
   };
   const client = Network.client(apiUrl, appDetails, auth);
-  const headers = headersWithBasicAuth(clientName, clientVersion, {
-    username: auth.bridgeUser,
-    password: auth.userId,
-  });
+  const headers = headersWithBasicAuth(
+    clientName,
+    clientVersion,
+    {
+      username: auth.bridgeUser,
+      password: auth.userId,
+    },
+    undefined,
+    { 'x-internxt-desktop-header': desktopHeader},
+  );
   return { client, headers };
 }


### PR DESCRIPTION
### Changes

1. Added `x-internxt-desktop-header` header to `headersWithAuthToken` and `headersWithBasicAuth` using AppDetails object.

### How to use

` const client = Network.client('url', {..., desktopHeader: 'token' }, ....)`

Note:
Branch off https://github.com/internxt/sdk/pull/280 