### PR TITLE
feat/upload thumnails using server wip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -13,6 +13,7 @@ import {
   CreateFolderByUuidPayload,
   CreateFolderPayload,
   CreateFolderResponse,
+  CreateThumbnailEntryPayload,
   DeleteFilePayload,
   DriveFileData,
   FetchFolderContentResponse,
@@ -438,6 +439,23 @@ export class Storage {
       '/storage/thumbnail',
       {
         thumbnail: thumbnailEntry,
+      },
+      addResourcesTokenToHeaders(this.headers(), resourcesToken),
+    );
+  }
+
+  /**
+   * Creates a new thumbnail entry using drive-server-wip
+   * @param CreateThumbnailEntryPayload
+   */
+  public createThumbnailEntryWithUUID(
+    thumbnailEntry: CreateThumbnailEntryPayload,
+    resourcesToken?: string,
+  ): Promise<Thumbnail> {
+    return this.client.post(
+      '/files/thumbnail',
+      {
+        ...thumbnailEntry,
       },
       addResourcesTokenToHeaders(this.headers(), resourcesToken),
     );

--- a/src/drive/storage/types.ts
+++ b/src/drive/storage/types.ts
@@ -291,6 +291,18 @@ export interface ThumbnailEntry {
   encrypt_version: EncryptionVersion;
 }
 
+export interface CreateThumbnailEntryPayload {
+  fileId: number;
+  fileUuid: string;
+  type: string;
+  size: number;
+  maxWidth: number;
+  maxHeight: number;
+  bucketId: string;
+  bucketFile: string;
+  encryptVersion: EncryptionVersion;
+}
+
 export interface CreateFolderPayload {
   parentFolderId: number;
   folderName: string;
@@ -447,8 +459,8 @@ export interface FolderMeta {
   bucket: string | null;
   parent_id: number | null;
   parentId: number | null;
-  parent_uuid:  string | null;
-  parentUuid:  string | null;
+  parent_uuid: string | null;
+  parentUuid: string | null;
   parent: string | null;
   created_at: string;
   createdAt: string;
@@ -457,8 +469,8 @@ export interface FolderMeta {
   user: string | null;
   user_id: number;
   userId: number;
-  encrypt_version:  string | null;
-  encryptVersion:  string | null;
+  encrypt_version: string | null;
+  encryptVersion: string | null;
   deleted: boolean;
   deleted_at: string | null;
   deletedAt: string | null;
@@ -467,8 +479,8 @@ export interface FolderMeta {
   removedAt: string | null;
   size: number;
   type: string;
-  creation_time:  string;
-  modification_time:  string;
+  creation_time: string;
+  modification_time: string;
 }
 
 export interface ReplaceFile {


### PR DESCRIPTION
New create thumbnail method that uses the new post `/files/thumbnail` in drive-server-wip.