### PR TITLE
[PB-4369]: feat/new limits usage endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.9.16",
+  "version": "1.9.17",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.9.17",
+  "version": "1.9.18",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -615,11 +615,19 @@ export class Storage {
     return this.client.get('/usage', this.headers());
   }
 
+  public spaceUsageV2(): Promise<UsageResponse> {
+    return this.client.get('/users/usage', this.headers());
+  }
+
   /**
    * Returns the current space limit for the user
    */
   public spaceLimit(): Promise<FetchLimitResponse> {
     return this.client.get('/limit', this.headers());
+  }
+
+  public spaceLimitV2(): Promise<FetchLimitResponse> {
+    return this.client.get('/users/limit', this.headers());
   }
 
   /**

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -611,22 +611,30 @@ export class Storage {
 
   /**
    * Returns the current space usage of the user
+   * @deprecated use `spaceUsageV2` call instead.
    */
   public spaceUsage(): Promise<UsageResponse> {
     return this.client.get('/usage', this.headers());
   }
 
+  /**
+   * Returns the current space usage of the user
+   */
   public spaceUsageV2(): Promise<UsageResponseV2> {
     return this.client.get('/users/usage', this.headers());
   }
 
   /**
    * Returns the current space limit for the user
+   * @deprecated use `spaceLimitV2` call instead.
    */
   public spaceLimit(): Promise<FetchLimitResponse> {
     return this.client.get('/limit', this.headers());
   }
 
+  /**
+   * Returns the current space limit for the user
+   */
   public spaceLimitV2(): Promise<FetchLimitResponse> {
     return this.client.get('/users/limit', this.headers());
   }

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -41,6 +41,7 @@ import {
   UpdateFilePayload,
   UpdateFolderMetadataPayload,
   UsageResponse,
+  UsageResponseV2,
 } from './types';
 
 export * as StorageTypes from './types';
@@ -615,7 +616,7 @@ export class Storage {
     return this.client.get('/usage', this.headers());
   }
 
-  public spaceUsageV2(): Promise<UsageResponse> {
+  public spaceUsageV2(): Promise<UsageResponseV2> {
     return this.client.get('/users/usage', this.headers());
   }
 

--- a/src/drive/storage/types.ts
+++ b/src/drive/storage/types.ts
@@ -396,6 +396,12 @@ export type UsageResponse = {
   [k in 'drive' | 'backups' | 'total']: number;
 };
 
+export type UsageResponseV2 = {
+  drive: number;
+  backups: number;
+  total: number;
+};
+
 export interface FetchLimitResponse {
   maxSpaceBytes: number;
 }

--- a/src/drive/storage/types.ts
+++ b/src/drive/storage/types.ts
@@ -292,7 +292,6 @@ export interface ThumbnailEntry {
 }
 
 export interface CreateThumbnailEntryPayload {
-  fileId: number;
   fileUuid: string;
   type: string;
   size: number;

--- a/test/drive/storage/index.test.ts
+++ b/test/drive/storage/index.test.ts
@@ -719,6 +719,22 @@ describe('# storage service tests', () => {
       });
     });
 
+    describe('space usage v2', () => {
+      it('should call with right params & return response', async () => {
+        const { client, headers } = clientAndHeaders({});
+        const callStub = sinon.stub(httpClient, 'get').resolves({
+          drive: 10,
+        });
+
+        const body = await client.spaceUsageV2();
+
+        expect(callStub.firstCall.args).toEqual(['/users/usage', headers]);
+        expect(body).toEqual({
+          drive: 10,
+        });
+      });
+    });
+
     describe('space limit', () => {
       it('should call with right params & return response', async () => {
         // Arrange
@@ -734,6 +750,22 @@ describe('# storage service tests', () => {
         expect(callStub.firstCall.args).toEqual(['/limit', headers]);
         expect(body).toEqual({
           total: 10,
+        });
+      });
+    });
+
+    describe('space limit v2', () => {
+      it('should call with right params & return response', async () => {
+        const { client, headers } = clientAndHeaders({});
+        const callStub = sinon.stub(httpClient, 'get').resolves({
+          maxSpaceBytes: 10,
+        });
+
+        const body = await client.spaceLimitV2();
+
+        expect(callStub.firstCall.args).toEqual(['/users/limit', headers]);
+        expect(body).toEqual({
+          maxSpaceBytes: 10,
         });
       });
     });
@@ -797,7 +829,6 @@ describe('# storage service tests', () => {
     describe('createThumbnailEntryWithUUID', () => {
       it('Should create a thumbnail entry with UUID and handle resourcesToken', async () => {
         const thumbnailEntryPayload: StorageTypes.CreateThumbnailEntryPayload = {
-          fileId: 123,
           fileUuid: v4(),
           type: 'image/jpeg',
           size: 1024,


### PR DESCRIPTION
Added two new methods to call the limit and usage endpoints on drive-server-wip. 
Removed fileId on the new create thumbnail endpoint to coincide with the changes introduced in drive-server-wip