### PR TITLE
[PB-3615]: feature/sharing info endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.9.28",
+  "version": "1.9.29",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/share/index.ts
+++ b/src/drive/share/index.ts
@@ -570,6 +570,12 @@ export class Share {
     return this.client.get(`sharings/${itemType}/${itemId}/type`, headers);
   }
 
+  /**
+   * Get Sharing information
+   * @param {string} options.itemType - folder | file
+   * @param {string} options.itemId - id of folder or file
+   * @returns {Promise<SharingInfo>} A promise that returns information about the shared item.
+   */
   public getSharingInfo({ itemId, itemType }: { itemId: string; itemType: string }): Promise<SharingInfo> {
     const headers = this.headers();
 

--- a/src/drive/share/index.ts
+++ b/src/drive/share/index.ts
@@ -25,6 +25,7 @@ import {
   SharedFolderSize,
   SharedFolderUser,
   SharedFoldersInvitationsAsInvitedUserResponse,
+  SharingInfo,
   SharingInvite,
   SharingMeta,
   UpdateShareLinkPayload,
@@ -567,6 +568,12 @@ export class Share {
     const headers = this.headers();
 
     return this.client.get(`sharings/${itemType}/${itemId}/type`, headers);
+  }
+
+  public getSharingInfo({ itemId, itemType }: { itemId: string; itemType: string }): Promise<SharingInfo> {
+    const headers = this.headers();
+
+    return this.client.get(`sharings/${itemType}/${itemId}/info`, headers);
   }
 
   public declineSharedFolderInvite(invitationId: string, token?: string): Promise<void> {

--- a/src/drive/share/index.ts
+++ b/src/drive/share/index.ts
@@ -563,7 +563,6 @@ export class Share {
    * @param {string} options.itemId - id of folder or file
    * @returns {Promise<SharingMeta>} A promise that returns the sharing data.
    */
-
   public getSharingType({ itemId, itemType }: { itemId: string; itemType: string }): Promise<SharingMeta> {
     const headers = this.headers();
 
@@ -571,7 +570,7 @@ export class Share {
   }
 
   /**
-   * Get Sharing information
+   * Obtains detailed sharing information for a given file or folder
    * @param {string} options.itemType - folder | file
    * @param {string} options.itemId - id of folder or file
    * @returns {Promise<SharingInfo>} A promise that returns information about the shared item.

--- a/src/drive/share/types.ts
+++ b/src/drive/share/types.ts
@@ -358,6 +358,16 @@ export type SharingMeta = {
   itemToken: string;
 };
 
+export type SharingInfo = {
+  type: 'public' | 'private';
+  publicSharing: {
+    id: string;
+    isPasswordProtected: boolean;
+    encryptedCode: string;
+  };
+  invitationsCount: number;
+};
+
 export type Sharing = { type: string; id: string };
 
 export type SharedFolderSize = { size: number };

--- a/test/drive/share/index.test.ts
+++ b/test/drive/share/index.test.ts
@@ -3,6 +3,7 @@ import {
   GenerateShareLinkPayload,
   GetSharedDirectoryPayload,
   SharedFiles,
+  SharingInfo,
   SharingMeta,
 } from '../../../src/drive/share/types';
 import { Share } from '../../../src/drive';
@@ -392,6 +393,31 @@ describe('# share service tests', () => {
       expect(body).toEqual({
         size: 30,
       });
+    });
+  });
+
+  describe('Get sharing info', () => {
+    it('When the sharing info is requested, then the right data should be returned', async () => {
+      const mockedResponse: SharingInfo = {
+        invitationsCount: 0,
+        publicSharing: {
+          encryptedCode: 'encrypted-code',
+          id: 'sharing-id',
+          isPasswordProtected: false,
+        },
+        type: 'public',
+      };
+      const callStub = sinon.stub(httpClient, 'get').resolves(mockedResponse);
+      const { client, headers } = clientAndHeadersWithToken();
+      const mockId = 'item-id';
+      const mockedItemType = 'item-type';
+
+      // Act
+      const body = await client.getSharingInfo({ itemId: mockId, itemType: mockedItemType });
+
+      // Assert
+      expect(callStub.firstCall.args).toEqual([`sharings/${mockedItemType}/${mockId}/info`, headers]);
+      expect(body).toStrictEqual(mockedResponse);
     });
   });
 


### PR DESCRIPTION
This PR adds a new endpoint to retrieve the type of a shared item. It allows us to determine whether the shared item is of type `public` or `private`, so that we can inform the user accordingly in the UI.