### PR TITLE
[PB-4499]: feat/allow custom headers for auth endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -550,7 +550,7 @@ export class Auth {
   }
 
   private basicHeaders() {
-    return basicHeaders(this.appDetails.clientName, this.appDetails.clientVersion);
+    return basicHeaders(this.appDetails.clientName, this.appDetails.clientVersion, this.appDetails.customHeaders);
   }
 
   private headersWithToken(token: Token) {


### PR DESCRIPTION
This PR adds support for custom HTTP headers in all authentication endpoints so clients can include a reCAPTCHA token via the `x-internxt-captcha` header.