### PR TITLE
[PB-4573]: feat/check if user already uploaded any file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -624,6 +624,13 @@ export class Storage {
   }
 
   /**
+   * @returns whether the user has uploaded any files
+   */
+  public hasUploadedFiles(): Promise<{ hasUploadedFiles: boolean }> {
+    return this.client.get('/users/me/upload-status', this.headers());
+  }
+
+  /**
    * Returns a list of the n most recent files
    * @param limit
    */


### PR DESCRIPTION
This PR adds a check to determine if the user has already uploaded at least one file.

By doing this, we no longer need to rely on the storage usage endpoint (which can take several minutes to update) to know whether the user has uploaded files to their account. This helps us avoid unnecessary delays when making UI decisions like showing or skipping the onboarding tutorial.