### PR TITLE
[_]: fix/use Axios putForm to correctly upload avatar image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -180,24 +180,26 @@ export class Users {
    * @param payload
    */
   public updateAvatar(payload: { avatar: Blob }) {
-    const formData = new FormData();
-    formData.set('avatar', payload.avatar);
-
-    return this.client.put<{ avatar: string }>('/user/avatar', formData, this.headers());
+    return this.client.putForm<{ avatar: string }>(
+      '/user/avatar',
+      {
+        avatar: payload.avatar,
+      },
+      this.headers(),
+    );
   }
 
   /**
    * Updates a user avatar
    * @param payload
    */
-  public updateUserAvatar(payload: { avatar: Blob }, token?: Token) {
-    const formData = new FormData();
-    formData.set('avatar', payload.avatar);
-
-    return this.client.put<{ avatar: string }>(
+  public async updateUserAvatar(payload: { avatar: Blob }, token?: Token) {
+    return this.client.putForm<{ avatar: string }>(
       '/users/avatar',
-      formData,
-      this.headersWithToken(token ?? <string>this.apiSecurity?.token),
+      {
+        avatar: payload.avatar,
+      },
+      this.headersWithToken(token ?? this.apiSecurity?.token),
     );
   }
 

--- a/src/shared/http/client.ts
+++ b/src/shared/http/client.ts
@@ -138,6 +138,18 @@ export class HttpClient {
   }
 
   /**
+   * Requests a PUT FORM
+   * @param url
+   * @param params
+   * @param headers
+   */
+  public putForm<Response>(url: URL, params: Parameters, headers: Headers): Promise<Response> {
+    return this.axios.putForm(url, params, {
+      headers: headers,
+    });
+  }
+
+  /**
    * Requests a DELETE
    * @param url
    * @param headers


### PR DESCRIPTION
This PR fixes an issue where the avatar image was not being correctly sent to the backend when updating the user's avatar. We now use Axios's `putForm` method to properly handle `FormData` and ensure the Blob is transmitted as expected. This change prevents missing payload issues.
