### PR TITLE
Remove sensible params from error

### DIFF
--- a/src/network/download.ts
+++ b/src/network/download.ts
@@ -59,14 +59,6 @@ export async function downloadFile(
         bucketId,
         fileId,
         user: network.credentials.username,
-        pass: network.credentials.password,
-        token: opts?.token || 'none',
-        crypto: {
-          index: indexHex! ? indexHex.toString('hex') : 'none',
-          iv: iv! ? iv.toString('hex') : 'none',
-          key: key! ? key.toString('hex') : 'none',
-          mnemonic,
-        },
       },
       err as Error,
     );

--- a/src/network/errors/context.ts
+++ b/src/network/errors/context.ts
@@ -6,27 +6,12 @@ export type NetworkUploadContext = {
   bucketId: string;
   fileSize: number;
   user: string;
-  pass: string;
-  crypto: {
-    index: string
-    mnemonic?: string;
-    key: string;
-    iv: string
-  }
-}
+};
 export type NetworkDownloadContext = {
   bucketId: string;
   fileId: string;
   user: string;
-  pass: string;
-  token: string;
-  crypto: {
-    index: string
-    mnemonic?: string;
-    key: string;
-    iv: string
-  }
-}
+};
 
 export type NetworkContext = NetworkUploadContext | NetworkDownloadContext;
 
@@ -38,12 +23,6 @@ export class ErrorWithContext extends Error {
 
 export function getNetworkErrorContext(input: NetworkContext, err: NetworkError): Partial<NetworkContext> {
   const output = Object.assign({}, input);
-
-  delete output.crypto.mnemonic;
-
-  if (err instanceof UploadInvalidMnemonicError || err instanceof DownloadInvalidMnemonicError) {
-    output.crypto.mnemonic = input.crypto.mnemonic;
-  }
 
   return output;
 }

--- a/src/network/upload.ts
+++ b/src/network/upload.ts
@@ -65,13 +65,6 @@ export async function uploadFile(
         bucketId,
         fileSize,
         user: network.credentials.username,
-        pass: network.credentials.password,
-        crypto: {
-          index: index! ? index.toString('hex') : 'none',
-          iv: iv! ? iv.toString('hex') : 'none',
-          key: key! ? key.toString('hex') : 'none',
-          mnemonic,
-        },
       },
       err as Error,
     );


### PR DESCRIPTION
## What

Remove sensible params from an error throw. This error was logged in `drive-desktop` and reported in `send-web` but I don't see any other usage that will break, so we can safely remove those params.
