### PR TITLE
[PB-3669]: feature/payments using crypto currencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.10.10",
+  "version": "1.10.11",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/payments/checkout.ts
+++ b/src/payments/checkout.ts
@@ -2,7 +2,13 @@ import { CreatedPaymentIntent, CreatedSubscriptionData } from '../drive/payments
 import { ApiSecurity, ApiUrl, AppDetails } from '../shared';
 import { basicHeaders, headersWithToken } from '../shared/headers';
 import { HttpClient } from '../shared/http/client';
-import { CreatePaymentIntentPayload, CreateSubscriptionPayload, GetPriceByIdPayload, PriceWithTax } from './types';
+import {
+  CreatePaymentIntentPayload,
+  CreateSubscriptionPayload,
+  CryptoCurrency,
+  GetPriceByIdPayload,
+  PriceWithTax,
+} from './types';
 
 export class Checkout {
   private readonly client: HttpClient;
@@ -139,6 +145,10 @@ export class Checkout {
     if (postalCode !== undefined) query.set('postalCode', postalCode);
     if (country !== undefined) query.set('country', country);
     return this.client.get<PriceWithTax>(`/checkout/price-by-id?${query.toString()}`, this.headers());
+  }
+
+  public getAvailableCryptoCurrencies(): Promise<CryptoCurrency[]> {
+    return this.client.get<CryptoCurrency[]>('/checkout/currencies/crypto', this.headers());
   }
 
   /**

--- a/src/payments/types/index.ts
+++ b/src/payments/types/index.ts
@@ -64,3 +64,12 @@ export type PriceWithTax = {
   price: Price;
   taxes: Taxes;
 };
+
+export interface CryptoCurrency {
+  currencyId: string;
+  name: string;
+  type: 'crypto' | 'fiat';
+  receiveType: boolean;
+  networks: { platformId: string; name: string }[];
+  imageUrl: string;
+}

--- a/test/payments/checkout.test.ts
+++ b/test/payments/checkout.test.ts
@@ -1,0 +1,83 @@
+import sinon from 'sinon';
+import { HttpClient } from '../../src/shared/http/client';
+import { Checkout } from '../../src/payments';
+import { ApiSecurity, AppDetails } from '../../src/shared';
+import { basicHeaders } from '../../src/shared/headers';
+import { CryptoCurrency } from '../../src/payments/types';
+
+const httpClient = HttpClient.create('');
+
+describe('Checkout service tests', () => {
+  beforeEach(() => {
+    sinon.stub(HttpClient, 'create').returns(httpClient);
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('Fetch available crypto currencies', () => {
+    it('should call with right params & return data', async () => {
+      // Arrange
+      const mockedCryptoCurrency: CryptoCurrency = {
+        currencyId: 'some-id',
+        imageUrl: 'http://some-url',
+        name: 'Bitcoin',
+        networks: [
+          {
+            platformId: 'bitcoin',
+            name: 'Bitcoin Network',
+          },
+        ],
+        receiveType: true,
+        type: 'crypto',
+      };
+      const callStub = sinon.stub(httpClient, 'get').resolves([mockedCryptoCurrency]);
+
+      const { client, headers } = clientAndHeadersWithToken({});
+
+      // Act
+      const body = await client.getAvailableCryptoCurrencies();
+
+      // Assert
+      expect(callStub.firstCall.args).toEqual(['/checkout/currencies/crypto', headers]);
+      expect(body).toStrictEqual([mockedCryptoCurrency]);
+    });
+  });
+});
+
+function clientAndHeadersWithToken({
+  apiUrl = '',
+  clientName = 'c-name',
+  clientVersion = '0.1',
+  token = 'token',
+  desktopHeader,
+}: {
+  apiUrl?: string;
+  clientName?: string;
+  clientVersion?: string;
+  token?: string;
+  desktopHeader?: string;
+}): {
+  client: Checkout;
+  headers: object;
+} {
+  const additionalHeaders: Record<string, string> = {};
+  const appDetails: AppDetails = {
+    clientName: clientName,
+    clientVersion: clientVersion,
+    desktopHeader: desktopHeader,
+  };
+  const apiSecurity: ApiSecurity = {
+    token: token,
+  };
+
+  if (desktopHeader) {
+    additionalHeaders['x-internxt-desktop-header'] = desktopHeader;
+  }
+
+  const client = Checkout.client(apiUrl, appDetails, apiSecurity);
+  const headers = basicHeaders(clientName, clientVersion);
+  return { client, headers };
+}


### PR DESCRIPTION
This PR introduces a new Checkout endpoint to retrieve the list of available cryptocurrencies, enabling users to purchase a plan using crypto.

Additionally, the response from the invoice creation endpoint has been updated to include the invoice type — either a Stripe invoice (for fiat currencies) or a Bit2Me invoice (for crypto payments).
If the user chooses to pay with crypto, the response will also include a QR code link to simplify the payment process.