### PR TITLE
[_]: feat/mail get encryption keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.15.11",
+  "version": "1.15.12",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/mail/api.ts
+++ b/src/mail/api.ts
@@ -22,6 +22,7 @@ import {
   EmailDomainsResponse,
   SetupMailAccountPayload,
   SearchFiltersQuery,
+  MailAccountKeysResponse,
 } from './types';
 
 export class MailApi {
@@ -198,6 +199,16 @@ export class MailApi {
    */
   async setupMailAccount(payload: SetupMailAccountPayload): Promise<{ address: string }> {
     return this.client.post('/users/me/mail-account', payload, this.headers());
+  }
+
+  /**
+   * Gets the mail account keys for the given address
+   *
+   * @param address - The mail address whose keys should be retrieved
+   * @returns The public, encrypted private and recovery keys plus the salt
+   */
+  async getMailAccountKeys(address: string): Promise<MailAccountKeysResponse> {
+    return this.client.getWithParams('/users/me/mail-account/keys', { address }, this.headers());
   }
 
   /**

--- a/src/mail/mail.ts
+++ b/src/mail/mail.ts
@@ -23,6 +23,7 @@ import {
   SearchFiltersQuery,
   EmailDomainsResponse,
   SetupMailAccountPayload,
+  MailAccountKeysResponse,
 } from './types';
 import { createKeystores, encryptEmail, passwordProtectAndSendEmail, openKeystore, recoverKeys } from './crypto';
 
@@ -257,5 +258,15 @@ export class Mail {
    */
   async setupMailAccount(payload: SetupMailAccountPayload): Promise<{ address: string }> {
     return this.api.setupMailAccount(payload);
+  }
+
+  /**
+   * Gets the mail account keys for the given address
+   *
+   * @param address - The mail address whose keys should be retrieved
+   * @returns The public, encrypted private and recovery keys plus the salt
+   */
+  async getMailAccountKeys(address: string): Promise<MailAccountKeysResponse> {
+    return this.api.getMailAccountKeys(address);
   }
 }

--- a/src/mail/types.ts
+++ b/src/mail/types.ts
@@ -24,3 +24,11 @@ export type SetupMailAccountPayload = {
     salt: string;
   };
 };
+
+export type MailAccountKeysResponse = {
+  address: string;
+  publicKey: string;
+  encryptionPrivateKey: string;
+  recoveryPrivateKey: string;
+  salt: string;
+};

--- a/src/mail/types.ts
+++ b/src/mail/types.ts
@@ -21,7 +21,6 @@ export type SetupMailAccountPayload = {
     publicKey: string;
     encryptionPrivateKey: string;
     recoveryPrivateKey: string;
-    salt: string;
   };
 };
 
@@ -30,5 +29,4 @@ export type MailAccountKeysResponse = {
   publicKey: string;
   encryptionPrivateKey: string;
   recoveryPrivateKey: string;
-  salt: string;
 };

--- a/test/mail/index.test.ts
+++ b/test/mail/index.test.ts
@@ -302,7 +302,6 @@ describe('Mail service tests', () => {
           publicKey: 'public-key',
           encryptionPrivateKey: 'encryption-private-key',
           recoveryPrivateKey: 'recovery-private-key',
-          salt: 'salt',
         },
       };
 
@@ -319,7 +318,6 @@ describe('Mail service tests', () => {
         publicKey: 'public-key',
         encryptionPrivateKey: 'encryption-private-key',
         recoveryPrivateKey: 'recovery-private-key',
-        salt: 'salt',
       };
       const getStub = vi.spyOn(HttpClient.prototype, 'getWithParams').mockResolvedValue(expectedKeys);
 

--- a/test/mail/index.test.ts
+++ b/test/mail/index.test.ts
@@ -311,6 +311,23 @@ describe('Mail service tests', () => {
       expect(postStub).toHaveBeenCalledWith('/users/me/mail-account', payload, headers);
       expect(result).toEqual({ address: 'user@domain.com' });
     });
+
+    it('When the mail account keys are requested, then it should GET /users/me/mail-account/keys with the address', async () => {
+      const { client, headers } = clientAndHeadersWithToken();
+      const expectedKeys = {
+        address: 'user@domain.com',
+        publicKey: 'public-key',
+        encryptionPrivateKey: 'encryption-private-key',
+        recoveryPrivateKey: 'recovery-private-key',
+        salt: 'salt',
+      };
+      const getStub = vi.spyOn(HttpClient.prototype, 'getWithParams').mockResolvedValue(expectedKeys);
+
+      const result = await client.getMailAccountKeys('user@domain.com');
+
+      expect(getStub).toHaveBeenCalledWith('/users/me/mail-account/keys', { address: 'user@domain.com' }, headers);
+      expect(result).toEqual(expectedKeys);
+    });
   });
 });
 


### PR DESCRIPTION
- Removed 'salt; references from create mail account method
- Added the getMailAccountKeys method to retrieve the user's keys for a given address