### PR TITLE
[PB-5978]: feat(mail)/add getMailAccount method to retrieve current mail account details

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/mail/index.ts
+++ b/src/mail/index.ts
@@ -14,6 +14,7 @@ import {
   SetupMailAccountPayload,
   SearchFiltersQuery,
   MailAccountKeysResponse,
+  MailAccountResponse,
   EncryptedKeystore,
   KeystoreType,
   RecipientWithPublicKey,
@@ -171,6 +172,16 @@ export class MailApi {
    */
   getActiveDomains(): Promise<EmailDomainsResponse> {
     return this.client.get('/email/domains', this.headers());
+  }
+
+  /**
+   * Returns the current mail account for the authenticated user, including its
+   * state, default address, and (when suspended) the scheduled deletion time.
+   *
+   * @returns The mail account details — `MailAccountResponse`
+   */
+  getMailAccount(): Promise<MailAccountResponse> {
+    return this.client.get('/users/me/mail-account', this.headers());
   }
 
   /**

--- a/src/mail/types.ts
+++ b/src/mail/types.ts
@@ -31,6 +31,14 @@ export type MailAccountKeysResponse = {
   recoveryPrivateKey: string;
 };
 
+export type MailAccountResponse = {
+  id: string;
+  defaultAddress: string;
+  status: 'active' | 'suspended';
+  suspendedAt?: string;
+  deletionAt?: string;
+};
+
 export type EncryptedKeystore = {
   userEmail: string;
   type: KeystoreType;

--- a/test/mail/index.test.ts
+++ b/test/mail/index.test.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '../../src/shared/http/client';
 import { MailApi } from '../../src/mail/index';
+import type { MailAccountResponse } from '../../src/mail/types';
 import { ApiSecurity, AppDetails } from '../../src/shared';
 import { headersWithToken } from '../../src/shared/headers';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -7,6 +8,47 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 describe('Mail service tests', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('getMailAccount', () => {
+    it('When the account is active, then it should GET /users/me/mail-account and return the account', async () => {
+      const { client, headers } = clientAndHeadersWithToken();
+      const response: MailAccountResponse = {
+        id: 'account-1',
+        defaultAddress: 'jane@inxt.me',
+        status: 'active',
+      };
+      const getStub = vi.spyOn(HttpClient.prototype, 'get').mockResolvedValue(response);
+
+      const result = await client.getMailAccount();
+
+      expect(getStub).toHaveBeenCalledWith('/users/me/mail-account', headers);
+      expect(result).toEqual(response);
+    });
+
+    it('When the account is suspended, then it should return suspendedAt and deletionAt timestamps', async () => {
+      const { client, headers } = clientAndHeadersWithToken();
+      const response: MailAccountResponse = {
+        id: 'account-1',
+        defaultAddress: 'jane@inxt.me',
+        status: 'suspended',
+        suspendedAt: '2026-05-01T00:00:00.000Z',
+        deletionAt: '2026-06-01T00:00:00.000Z',
+      };
+      const getStub = vi.spyOn(HttpClient.prototype, 'get').mockResolvedValue(response);
+
+      const result = await client.getMailAccount();
+
+      expect(getStub).toHaveBeenCalledWith('/users/me/mail-account', headers);
+      expect(result).toEqual(response);
+    });
+
+    it('When the HTTP client throws, then the error should propagate', async () => {
+      const { client } = clientAndHeadersWithToken();
+      vi.spyOn(HttpClient.prototype, 'get').mockRejectedValue(new Error('Unauthorized'));
+
+      await expect(client.getMailAccount()).rejects.toThrow('Unauthorized');
+    });
   });
 
   describe('test mail account setup', () => {


### PR DESCRIPTION
Add `getMailAccount `method to mail SDK

Exposes a new getMailAccount method on the mail client that fetches the current user's mail account details.