### PR TITLE
[_] make payload obligatory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/meet/index.ts
+++ b/src/meet/index.ts
@@ -28,10 +28,10 @@ export class Meet {
     return this.client.post<JoinCallResponse>(`call/${callId}/users/join`, { ...payload }, headers);
   }
 
-  async leaveCall(callId: string, payload?: LeaveCallPayload): Promise<void> {
+  async leaveCall(callId: string, payload: LeaveCallPayload): Promise<void> {
     const headers = this.apiSecurity?.token ? this.headersWithToken() : this.basicHeaders();
 
-    return this.client.postWithKeepAlive<void>(`call/${callId}/users/leave`, payload ? { ...payload } : {}, headers);
+    return this.client.postWithKeepAlive<void>(`call/${callId}/users/leave`, { ...payload }, headers);
   }
 
   async getCurrentUsersInCall(callId: string): Promise<UsersInCallResponse[]> {

--- a/test/drive/meet/index.test.ts
+++ b/test/drive/meet/index.test.ts
@@ -137,30 +137,6 @@ describe('Meet service tests', () => {
   describe('leaveCall method', () => {
     const callId = 'call-123';
 
-    it('should leave a call successfully with token and no payload', async () => {
-      // Arrange
-      const { client, headers } = clientAndHeadersWithToken();
-      const postCall = vi.spyOn(HttpClient.prototype, 'postWithKeepAlive').mockResolvedValue(undefined);
-
-      // Act
-      await client.leaveCall(callId);
-
-      // Assert
-      expect(postCall).toHaveBeenCalledWith(`call/${callId}/users/leave`, {}, headers);
-    });
-
-    it('should leave a call successfully without token and no payload', async () => {
-      // Arrange
-      const { client, headers } = clientAndHeadersWithoutToken();
-      const postCall = vi.spyOn(HttpClient.prototype, 'postWithKeepAlive').mockResolvedValue(undefined);
-
-      // Act
-      await client.leaveCall(callId);
-
-      // Assert
-      expect(postCall).toHaveBeenCalledWith(`call/${callId}/users/leave`, {}, headers);
-    });
-
     it('should send userId in body when anonymous user leaves with token', async () => {
       const payload: LeaveCallPayload = { userId: 'anon-uuid-456' };
       const { client, headers } = clientAndHeadersWithToken();


### PR DESCRIPTION
Fix for kick out. Right now, leaveCall takes the userID from the token or payload. However, with the token, it's the same ID for all user copies. Hence, if the 'user Original' leaves and sends leaveCall it sends it with the userID (in token), which now belongs to the 'user Duplicate' in the database, and the record gets deleted. 

We'll switch to IDs instead of userIDs. But the first step is to make the payload mandatory