### PR TITLE
[PB-6479]: feature/add deliveryMode when sending emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/mail/schema.ts
+++ b/src/mail/schema.ts
@@ -591,6 +591,11 @@ export interface components {
       htmlBody?: string;
       encryption?: components['schemas']['EncryptionBlockDto'];
       attachments?: components['schemas']['AttachmentRefDto'][];
+      /**
+       * @example INTERNXT
+       * @enum {string}
+       */
+      deliveryMode?: 'INTERNXT' | 'EXTERNAL';
     };
     EmailCreatedResponseDto: {
       /**

--- a/src/mail/types.ts
+++ b/src/mail/types.ts
@@ -20,6 +20,7 @@ export type EmailDomainsResponse = components['schemas']['MailDomainDto'][];
 export type UploadAttachmentResponse = components['schemas']['UploadAttachmentResponseDto'];
 export type DownloadAttachmentPayload = operations['EmailController_downloadAttachment']['parameters']['query'];
 export type AttachmentRef = components['schemas']['EmailAttachmentDto'];
+export type DeliveryMode = components['schemas']['SendEmailRequestDto']['deliveryMode'];
 export type DownloadAttachmentResponse = {
   data: ArrayBuffer;
   contentType: string;


### PR DESCRIPTION
Adding new field to Send Email Payload called **deliveryMode** so we can specify if the emails are for EXTERNALS or INTERNXT.