### PR TITLE
[_]: refactor/expose-entire-file-metadata-on-download

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.17.7",
+  "version": "1.17.8",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/network/download.ts
+++ b/src/network/download.ts
@@ -40,7 +40,8 @@ export async function downloadFile(
       }
     }
 
-    const { index, shards, version, size } = await network.getDownloadLinks(bucketId, fileId, opts?.token);
+    const fileInfo = await network.getDownloadLinks(bucketId, fileId, opts?.token);
+    const { index, shards, version, size } = fileInfo;
 
     if (!version || version === 1) {
       throw new FileVersionOneError();
@@ -50,7 +51,7 @@ export async function downloadFile(
     key = await crypto.generateFileKey(mnemonic, bucketId, toBinaryData(index, BinaryDataEncoding.HEX));
     const downloadables = shards.sort((sA, sB) => sA.index - sB.index);
 
-    await downloadFile(downloadables, size);
+    await downloadFile(downloadables, fileInfo);
     await decryptFile(crypto.algorithm.type, key, iv, size);
   } catch (err) {
     const context = getNetworkErrorContext(

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -45,6 +45,10 @@ export interface GetDownloadLinksResponse {
   shards: DownloadableShard[];
   version?: number;
   size: number;
+  hmac?: {
+    value: string;
+    type: 'sha512';
+  };
 }
 
 export interface NetworkRequestConfig {
@@ -76,7 +80,10 @@ export type UploadFileFunction = (url: string) => Promise<Hash>;
 export type UploadFileMultipartFunction = (
   urls: string[],
 ) => Promise<{ hash: Hash; parts: { PartNumber: number; ETag: string }[] }>;
-export type DownloadFileFunction = (downloadables: DownloadableShard[], fileSize: number) => Promise<void>;
+export type DownloadFileFunction = (
+  downloadables: DownloadableShard[],
+  fileInfo: GetDownloadLinksResponse,
+) => Promise<void>;
 
 export type BinaryData = {
   slice: (from: number, to: number) => BinaryData;

--- a/test/network/download.test.ts
+++ b/test/network/download.test.ts
@@ -105,7 +105,7 @@ describe('network/download', () => {
           expect(generateFileKeyStub).toHaveBeenCalledWith(mnemonic, bucketId, bufferizedIndex);
 
           expect(downloadFileMock).toHaveBeenCalledTimes(1);
-          expect(downloadFileMock).toHaveBeenCalledWith(shards, fileSize);
+          expect(downloadFileMock).toHaveBeenCalledWith(shards, expect.objectContaining({ size: fileSize }));
 
           expect(decryptFileMock).toHaveBeenCalledTimes(1);
           expect(decryptFileMock).toHaveBeenCalledWith(
@@ -185,7 +185,7 @@ describe('network/download', () => {
           expect(generateFileKeyStub).toHaveBeenCalledWith(mnemonic, bucketId, bufferizedIndex);
 
           expect(downloadFileMock).toHaveBeenCalledTimes(1);
-          expect(downloadFileMock).toHaveBeenCalledWith(shards, fileSize);
+          expect(downloadFileMock).toHaveBeenCalledWith(shards, expect.objectContaining({ size: fileSize }));
 
           expect(decryptFileMock).toHaveBeenCalledTimes(1);
           expect(decryptFileMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## What 
Exposing the entire file metadata to any consumer of the network consumer

## Why 
Because it is useful to modifications on this process that may involve knowing some info about the file's metadata on the network.