### PR TITLE
[_]: feat/store-HMAC-in-network-finish-upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.17.8",
+  "version": "1.17.9",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -66,14 +66,21 @@ export type StartUploadPayload = {
   uploads: UploadPayload[];
 };
 
+export type HmacPayload = {
+  type: 'sha512';
+  value: string;
+};
+
 export type FinishUploadPayload = {
   index: string;
   shards: Shard[];
+  hmac?: HmacPayload;
 };
 
 export type FinishMultipartUploadPayload = {
   index: string;
   shards: ShardForMultipart[];
+  hmac?: HmacPayload;
 };
 
 export type UploadFileFunction = (url: string) => Promise<Hash>;
@@ -117,6 +124,7 @@ export type Crypto = {
   validateMnemonic: (mnemonic: string) => boolean;
   randomBytes: (bytesLength: number) => BinaryData;
   generateFileKey: (mnemonic: string, bucketId: string, index: BinaryData | string) => Promise<BinaryData>;
+  computeHmac?: (key: BinaryData, shardHashes: string[]) => Promise<HmacPayload>;
 };
 
 export type EncryptFileFunction = (

--- a/src/network/upload.ts
+++ b/src/network/upload.ts
@@ -44,10 +44,12 @@ export async function uploadFile(
 
     await encryptFile(crypto.algorithm.type, key, iv);
     const hash = await uploadFile(url);
+    const hmac = crypto.computeHmac ? await crypto.computeHmac(key, [hash]) : undefined;
 
     const finishUploadPayload = {
       index: index.toString('hex'),
       shards: [{ hash, uuid }],
+      hmac,
     };
 
     const finishUploadResponse = await network.finishUpload(bucketId, finishUploadPayload, signal);
@@ -106,10 +108,12 @@ export async function uploadMultipartFile(
 
   await encryptFile(crypto.algorithm.type, key, iv);
   const { hash, parts: uploadedPartsReference } = await uploadMultiparts(urls);
+  const hmac = crypto.computeHmac ? await crypto.computeHmac(key, [hash]) : undefined;
 
   const finishUploadPayload = {
     index: index.toString('hex'),
     shards: [{ hash, uuid, UploadId, parts: uploadedPartsReference }],
+    hmac,
   };
 
   const finishUploadResponse = await network.finishMultipartUpload(bucketId, finishUploadPayload, signal);

--- a/test/network/upload.test.ts
+++ b/test/network/upload.test.ts
@@ -125,6 +125,84 @@ describe('network/upload', () => {
       expect(receivedFileId).toEqual(fileId);
     });
 
+    it('Should include hmac in finishUpload payload when computeHmac is provided', async () => {
+      const bucketId = fakeBucketId;
+      const mnemonic = fakeMnemonic;
+      const fileSize = 1000;
+      const fakeUrl = 'http://x.com';
+      const fakeUuid = 'b541b138-a6f2-4729-8d20-8e6011cb8216';
+      const index = 'aabdfb3018eb9e93bd9a31936aad979bed83abcc60fd79c15c15f44321024f46';
+      const bufferizedIndex = Buffer.from(index, 'hex');
+      const key = Buffer.from('');
+      const fakeHmac = { type: 'sha512' as const, value: 'deadbeef' };
+
+      const computeHmacMock = vi.fn().mockResolvedValue(fakeHmac);
+      const cryptoWithHmac: Crypto = { ...crypto, computeHmac: computeHmacMock };
+
+      vi.spyOn(cryptoWithHmac, 'randomBytes').mockReturnValue(bufferizedIndex);
+      vi.spyOn(cryptoWithHmac, 'generateFileKey').mockResolvedValue(key);
+      vi.spyOn(cryptoWithHmac, 'validateMnemonic').mockReturnValue(true);
+      vi.spyOn(network, 'startUpload').mockResolvedValue({
+        uploads: [{ url: fakeUrl, uuid: fakeUuid, index: 0, urls: null }],
+      });
+      const finishUploadStub = vi.spyOn(network, 'finishUpload').mockResolvedValue({
+        bucket: '',
+        created: new Date(),
+        id: fakeFileId,
+        index,
+        mimetype: 'application/octet-stream',
+        name: '',
+      });
+
+      const uploadFileMock = vi.fn().mockReturnValue(fakeHash);
+
+      await uploadFile(network, cryptoWithHmac, bucketId, mnemonic, fileSize, vi.fn(), uploadFileMock, abortSignal);
+
+      expect(computeHmacMock).toHaveBeenCalledOnce();
+      expect(computeHmacMock).toHaveBeenCalledWith(key, [fakeHash]);
+      expect(finishUploadStub).toHaveBeenCalledWith(bucketId, expect.objectContaining({ hmac: fakeHmac }), abortSignal);
+    });
+
+    it('Should not include hmac in finishUpload payload when computeHmac is not provided', async () => {
+      const bucketId = fakeBucketId;
+      const mnemonic = fakeMnemonic;
+      const fileSize = 1000;
+      const fakeUrl = 'http://x.com';
+      const fakeUuid = 'b541b138-a6f2-4729-8d20-8e6011cb8216';
+      const index = 'aabdfb3018eb9e93bd9a31936aad979bed83abcc60fd79c15c15f44321024f46';
+      const bufferizedIndex = Buffer.from(index, 'hex');
+      const key = Buffer.from('');
+
+      vi.spyOn(crypto, 'randomBytes').mockReturnValue(bufferizedIndex);
+      vi.spyOn(crypto, 'generateFileKey').mockResolvedValue(key);
+      vi.spyOn(crypto, 'validateMnemonic').mockReturnValue(true);
+      vi.spyOn(network, 'startUpload').mockResolvedValue({
+        uploads: [{ url: fakeUrl, uuid: fakeUuid, index: 0, urls: null }],
+      });
+      const finishUploadStub = vi.spyOn(network, 'finishUpload').mockResolvedValue({
+        bucket: '',
+        created: new Date(),
+        id: fakeFileId,
+        index,
+        mimetype: 'application/octet-stream',
+        name: '',
+      });
+
+      await uploadFile(
+        network,
+        crypto,
+        bucketId,
+        mnemonic,
+        fileSize,
+        vi.fn(),
+        vi.fn().mockReturnValue(fakeHash),
+        abortSignal,
+      );
+
+      const payload = finishUploadStub.mock.calls[0][1];
+      expect(payload.hmac).toBeUndefined();
+    });
+
     it('Should throw if the mnemonic is invalid', async () => {
       const bucketId = fakeBucketId;
       const mnemonic = fakeMnemonic;


### PR DESCRIPTION
## What 
Storing the computed HMAC of a file when finishing its upload.

## Why 
To perform the integrity check on the download. Related to #409 