### PR TITLE
[PB-6505] make old UserSettings fields optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.17.12",
+  "version": "1.17.14",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.17.14",
+  "version": "1.18.0",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/shared/types/userSettings.ts
+++ b/src/shared/types/userSettings.ts
@@ -18,9 +18,9 @@ export interface UserSettings {
   sharedWorkspace: boolean;
   credit: number;
   mnemonic: string;
-  privateKey: string;
-  publicKey: string;
-  revocationKey: string;
+  privateKey?: string;
+  publicKey?: string;
+  revocationKey?: string;
   keys: {
     ecc: {
       publicKey: string;

--- a/src/shared/types/userSettings.ts
+++ b/src/shared/types/userSettings.ts
@@ -18,9 +18,6 @@ export interface UserSettings {
   sharedWorkspace: boolean;
   credit: number;
   mnemonic: string;
-  privateKey?: string;
-  publicKey?: string;
-  revocationKey?: string;
   keys: {
     ecc: {
       publicKey: string;


### PR DESCRIPTION
Removes old key fields in UserSettings so drive-web can remove them.

Required for https://github.com/internxt/drive-web/pull/2033