### PR TITLE
[MKT_923]:feat/refactor CreateCustomerPayload to match checkout customer EP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.17.18",
+  "version": "1.17.19",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/payments/checkout.ts
+++ b/src/payments/checkout.ts
@@ -29,14 +29,13 @@ export class Checkout {
 
   /**
    * @description Creates a customer or gets the existing one if it already exists
-   * @param customerName - The name of the customer
-   * @param lineAddress1 - The address of the user
-   * @param lineAddress2 - The address of the user
-   * @param postalCode - The postal code of the city where the user lives
-   * @param city - The city of the user
    * @param country - The country of the customer
-   * @param postalCode - The postal code of the customer
    * @param captchaToken - The captcha token to verify the call
+   * @param customerName - The name of the customer (optional)
+   * @param lineAddress1 - The address of the user (optional)
+   * @param lineAddress2 - The second address line of the user (optional)
+   * @param city - The city of the user (optional)
+   * @param postalCode - The postal code of the customer (optional)
    * @param companyVatId - The VAT ID of the company (optional)
    * @param metadata - Additional metadata to attach to the customer (optional)
    * @returns The customer ID and the user token used to create a subscription or payment intent

--- a/src/payments/types/index.ts
+++ b/src/payments/types/index.ts
@@ -1,12 +1,12 @@
 import { UserType } from '../../drive/payments/types/types';
 
 export interface CreateCustomerPayload {
-  customerName: string;
-  lineAddress1: string;
+  customerName?: string;
+  lineAddress1?: string;
   lineAddress2?: string;
-  city: string;
+  city?: string;
   country: string;
-  postalCode: string;
+  postalCode?: string;
   captchaToken: string;
   companyVatId?: string;
   metadata?: Record<string, string>;


### PR DESCRIPTION
In this PR we mark the `customerName`, `lineAddress1`, `city` and `postalCode` fields of `CreateCustomerPayload` as optional, so the type now matches the actual contract of `POST /checkout/customer` in the payments backend, where only `country` and `captchaToken` are required by the schema. We also fixed the `createCustomer` JSDoc, since `postalCode` was documented twice and the optional params were not marked as such.
