### PR TITLE
[PB-6649]: feat/add advanced search filters to global search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -27,6 +27,7 @@ import {
   FileVersion,
   FolderAncestor,
   FolderAncestorWorkspace,
+  GlobalSearchOptions,
   FolderMeta,
   FolderStatsResponse,
   FolderTreeResponse,
@@ -655,16 +656,27 @@ export class Storage {
    *
    * @param {string} search - The name of the item.
    * @param {string} workspaceId - The ID of the workspace (optional).
-   * @param {number} offset - The position of the first item to return (optional).
+   * @param {number | GlobalSearchOptions} offsetOrOptions - The position of the first item to return, or an options
+   * object (optional) with the offset and the search filters: `type` (file categories, combined with OR),
+   * `minSize`/`maxSize` (bytes, files only) and `modifiedAfter`/`modifiedBefore` (ISO 8601 dates). Filters are
+   * combined with AND.
    * @returns {[Promise<SearchResultData>, RequestCanceler]} An array containing a promise to get the API response and a function to cancel the request.
    */
   public getGlobalSearchItems(
     search: string,
     workspaceId?: string,
-    offset?: number,
+    offsetOrOptions?: number | GlobalSearchOptions,
   ): [Promise<SearchResultData>, RequestCanceler] {
+    const options: GlobalSearchOptions =
+      typeof offsetOrOptions === 'number' ? { offset: offsetOrOptions } : (offsetOrOptions ?? {});
+
     const query = new URLSearchParams();
-    if (offset !== undefined) query.set('offset', String(offset));
+    if (options.offset !== undefined) query.set('offset', String(options.offset));
+    options.type?.forEach((category) => query.append('type', category));
+    if (options.minSize !== undefined) query.set('minSize', String(options.minSize));
+    if (options.maxSize !== undefined) query.set('maxSize', String(options.maxSize));
+    if (options.modifiedAfter !== undefined) query.set('modifiedAfter', options.modifiedAfter);
+    if (options.modifiedBefore !== undefined) query.set('modifiedBefore', options.modifiedBefore);
 
     const { promise, requestCanceler } = workspaceId
       ? this.client.getCancellable<SearchResultData>(

--- a/src/drive/storage/index.ts
+++ b/src/drive/storage/index.ts
@@ -675,20 +675,13 @@ export class Storage {
     const options: GlobalSearchOptions =
       typeof offsetOrOptions === 'number' ? { offset: offsetOrOptions } : (offsetOrOptions ?? {});
 
-    const query = new URLSearchParams();
-    if (options.offset !== undefined) query.set('offset', String(options.offset));
-    options.type?.forEach((category) => query.append('type', category));
-    if (options.minSize !== undefined) query.set('minSize', String(options.minSize));
-    if (options.maxSize !== undefined) query.set('maxSize', String(options.maxSize));
-    if (options.modifiedAfter !== undefined) query.set('modifiedAfter', options.modifiedAfter);
-    if (options.modifiedBefore !== undefined) query.set('modifiedBefore', options.modifiedBefore);
-
     const { promise, requestCanceler } = workspaceId
-      ? this.client.getCancellable<SearchResultData>(
-          `workspaces/${workspaceId}/fuzzy/${search}?${query}`,
+      ? this.client.postCancellable<SearchResultData>(
+          `workspaces/${workspaceId}/fuzzy/${search}`,
+          options,
           this.headers(),
         )
-      : this.client.getCancellable<SearchResultData>(`fuzzy/${search}?${query}`, this.headers());
+      : this.client.postCancellable<SearchResultData>(`fuzzy/${search}`, options, this.headers());
 
     return [promise, requestCanceler];
   }

--- a/src/drive/storage/types.ts
+++ b/src/drive/storage/types.ts
@@ -360,6 +360,31 @@ export interface SearchResultData {
   data: [SearchResult];
 }
 
+export type SearchFileCategory =
+  | 'folder'
+  | 'audio'
+  | 'code'
+  | 'csv'
+  | 'figma'
+  | 'image'
+  | 'pdf'
+  | 'ppt'
+  | 'txt'
+  | 'video'
+  | 'word'
+  | 'xls'
+  | 'xml'
+  | 'zip';
+
+export interface GlobalSearchOptions {
+  offset?: number;
+  type?: SearchFileCategory[];
+  minSize?: number;
+  maxSize?: number;
+  modifiedAfter?: string;
+  modifiedBefore?: string;
+}
+
 export interface FolderAncestor {
   bucket: null | string;
   createdAt: string;

--- a/src/drive/storage/types.ts
+++ b/src/drive/storage/types.ts
@@ -365,8 +365,6 @@ export interface SearchResultData {
 
 export type GlobalSearchOptions = NonNullable<operations['FuzzySearchController_fuzzySearch']['parameters']['query']>;
 
-export type SearchFileCategory = NonNullable<GlobalSearchOptions['type']>[number];
-
 export interface FolderAncestor {
   bucket: null | string;
   createdAt: string;

--- a/src/drive/storage/types.ts
+++ b/src/drive/storage/types.ts
@@ -1,4 +1,4 @@
-import { components, operations, paths } from '../../schema';
+import { components, paths } from '../../schema';
 import { UserResumeData } from '../users/types';
 
 export interface DriveFolderData {
@@ -363,7 +363,7 @@ export interface SearchResultData {
   data: [SearchResult];
 }
 
-export type GlobalSearchOptions = NonNullable<operations['FuzzySearchController_fuzzySearch']['parameters']['query']>;
+export type GlobalSearchOptions = paths['/fuzzy/{search}']['post']['requestBody']['content']['application/json'];
 
 export interface FolderAncestor {
   bucket: null | string;

--- a/src/drive/storage/types.ts
+++ b/src/drive/storage/types.ts
@@ -1,4 +1,4 @@
-import { paths } from '../../schema';
+import { operations, paths } from '../../schema';
 import { UserResumeData } from '../users/types';
 
 export interface DriveFolderData {
@@ -360,30 +360,9 @@ export interface SearchResultData {
   data: [SearchResult];
 }
 
-export type SearchFileCategory =
-  | 'folder'
-  | 'audio'
-  | 'code'
-  | 'csv'
-  | 'figma'
-  | 'image'
-  | 'pdf'
-  | 'ppt'
-  | 'txt'
-  | 'video'
-  | 'word'
-  | 'xls'
-  | 'xml'
-  | 'zip';
+export type GlobalSearchOptions = NonNullable<operations['FuzzySearchController_fuzzySearch']['parameters']['query']>;
 
-export interface GlobalSearchOptions {
-  offset?: number;
-  type?: SearchFileCategory[];
-  minSize?: number;
-  maxSize?: number;
-  modifiedAfter?: string;
-  modifiedBefore?: string;
-}
+export type SearchFileCategory = NonNullable<GlobalSearchOptions['type']>[number];
 
 export interface FolderAncestor {
   bucket: null | string;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -8949,23 +8949,8 @@ export interface operations {
       query?: {
         /** @description Offset for pagination */
         offset?: number;
-        /** @description File categories to filter by (single value or repeated param) */
-        type?: (
-          | 'folder'
-          | 'audio'
-          | 'code'
-          | 'csv'
-          | 'figma'
-          | 'image'
-          | 'pdf'
-          | 'ppt'
-          | 'txt'
-          | 'video'
-          | 'word'
-          | 'xls'
-          | 'xml'
-          | 'zip'
-        )[];
+        /** @description File extensions to filter by, or the reserved value "folder" to include folders (single value or repeated param) */
+        type?: string[];
         /** @description Minimum file size in bytes (folders are excluded) */
         minSize?: number;
         /** @description Maximum file size in bytes (folders are excluded) */
@@ -9061,23 +9046,8 @@ export interface operations {
       query?: {
         /** @description Offset for pagination */
         offset?: number;
-        /** @description File categories to filter by (single value or repeated param) */
-        type?: (
-          | 'folder'
-          | 'audio'
-          | 'code'
-          | 'csv'
-          | 'figma'
-          | 'image'
-          | 'pdf'
-          | 'ppt'
-          | 'txt'
-          | 'video'
-          | 'word'
-          | 'xls'
-          | 'xml'
-          | 'zip'
-        )[];
+        /** @description File extensions to filter by, or the reserved value "folder" to include folders (single value or repeated param) */
+        type?: string[];
         /** @description Minimum file size in bytes (folders are excluded) */
         minSize?: number;
         /** @description Maximum file size in bytes (folders are excluded) */

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -8850,8 +8850,34 @@ export interface operations {
   };
   WorkspacesController_searchWorkspace: {
     parameters: {
-      query: {
-        offset: number;
+      query?: {
+        /** @description Offset for pagination */
+        offset?: number;
+        /** @description File categories to filter by (single value or repeated param) */
+        type?: (
+          | 'folder'
+          | 'audio'
+          | 'code'
+          | 'csv'
+          | 'figma'
+          | 'image'
+          | 'pdf'
+          | 'ppt'
+          | 'txt'
+          | 'video'
+          | 'word'
+          | 'xls'
+          | 'xml'
+          | 'zip'
+        )[];
+        /** @description Minimum file size in bytes (folders are excluded) */
+        minSize?: number;
+        /** @description Maximum file size in bytes (folders are excluded) */
+        maxSize?: number;
+        /** @description Filter items modified after this date */
+        modifiedAfter?: string;
+        /** @description Filter items modified before this date */
+        modifiedBefore?: string;
       };
       header?: never;
       path: {
@@ -8936,8 +8962,34 @@ export interface operations {
   };
   FuzzySearchController_fuzzySearch: {
     parameters: {
-      query: {
-        offset: number;
+      query?: {
+        /** @description Offset for pagination */
+        offset?: number;
+        /** @description File categories to filter by (single value or repeated param) */
+        type?: (
+          | 'folder'
+          | 'audio'
+          | 'code'
+          | 'csv'
+          | 'figma'
+          | 'image'
+          | 'pdf'
+          | 'ppt'
+          | 'txt'
+          | 'video'
+          | 'word'
+          | 'xls'
+          | 'xml'
+          | 'zip'
+        )[];
+        /** @description Minimum file size in bytes (folders are excluded) */
+        minSize?: number;
+        /** @description Maximum file size in bytes (folders are excluded) */
+        maxSize?: number;
+        /** @description Filter items modified after this date */
+        modifiedAfter?: string;
+        /** @description Filter items modified before this date */
+        modifiedBefore?: string;
       };
       header?: never;
       path: {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2305,10 +2305,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Search by name inside workspace */
-    get: operations['WorkspacesController_searchWorkspace'];
+    get?: never;
     put?: never;
-    post?: never;
+    /** Search by name inside workspace */
+    post: operations['WorkspacesController_searchWorkspace'];
     delete?: never;
     options?: never;
     head?: never;
@@ -2376,10 +2376,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Search for items from a part of the name */
-    get: operations['FuzzySearchController_fuzzySearch'];
+    get?: never;
     put?: never;
-    post?: never;
+    /** Search for items from a part of the name */
+    post: operations['FuzzySearchController_fuzzySearch'];
     delete?: never;
     options?: never;
     head?: never;
@@ -4797,6 +4797,42 @@ export interface components {
        * @example +34 622 111 333
        */
       phoneNumber: Record<string, never>;
+    };
+    FuzzySearchQueryDto: {
+      /**
+       * @description Offset for pagination
+       * @example 0
+       */
+      offset?: number;
+      /**
+       * @description File extensions to filter by, or the reserved value "folder" to include folders (a single string is also accepted)
+       * @example [
+       *       "jpg",
+       *       "pdf",
+       *       "folder"
+       *     ]
+       */
+      type?: string[];
+      /**
+       * @description Minimum file size in bytes (folders are excluded)
+       * @example 5242880
+       */
+      minSize?: number;
+      /**
+       * @description Maximum file size in bytes (folders are excluded)
+       * @example 1073741824
+       */
+      maxSize?: number;
+      /**
+       * @description Filter items modified after this date
+       * @example 2026-01-01T00:00:00.000Z
+       */
+      modifiedAfter?: string;
+      /**
+       * @description Filter items modified before this date
+       * @example 2026-06-30T23:59:59.999Z
+       */
+      modifiedBefore?: string;
     };
     FuzzySearchResult: {
       id: string;
@@ -8946,20 +8982,7 @@ export interface operations {
   };
   WorkspacesController_searchWorkspace: {
     parameters: {
-      query?: {
-        /** @description Offset for pagination */
-        offset?: number;
-        /** @description File extensions to filter by, or the reserved value "folder" to include folders (single value or repeated param) */
-        type?: string[];
-        /** @description Minimum file size in bytes (folders are excluded) */
-        minSize?: number;
-        /** @description Maximum file size in bytes (folders are excluded) */
-        maxSize?: number;
-        /** @description Filter items modified after this date */
-        modifiedAfter?: string;
-        /** @description Filter items modified before this date */
-        modifiedBefore?: string;
-      };
+      query?: never;
       header?: never;
       path: {
         search: string;
@@ -8967,7 +8990,11 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['FuzzySearchQueryDto'];
+      };
+    };
     responses: {
       /** @description Search results */
       200: {
@@ -9043,27 +9070,18 @@ export interface operations {
   };
   FuzzySearchController_fuzzySearch: {
     parameters: {
-      query?: {
-        /** @description Offset for pagination */
-        offset?: number;
-        /** @description File extensions to filter by, or the reserved value "folder" to include folders (single value or repeated param) */
-        type?: string[];
-        /** @description Minimum file size in bytes (folders are excluded) */
-        minSize?: number;
-        /** @description Maximum file size in bytes (folders are excluded) */
-        maxSize?: number;
-        /** @description Filter items modified after this date */
-        modifiedAfter?: string;
-        /** @description Filter items modified before this date */
-        modifiedBefore?: string;
-      };
+      query?: never;
       header?: never;
       path: {
         search: string;
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['FuzzySearchQueryDto'];
+      };
+    };
     responses: {
       /** @description Elements found */
       200: {

--- a/test/drive/storage/index.test.ts
+++ b/test/drive/storage/index.test.ts
@@ -10,6 +10,7 @@ import {
   FolderAncestorWorkspace,
   MoveFolderPayload,
   MoveFolderResponse,
+  SearchResultData,
   UpdateFilePayload,
 } from '../../../src/drive/storage/types';
 import { ApiSecurity, AppDetails } from '../../../src/shared';
@@ -915,6 +916,74 @@ describe('# storage service tests', () => {
         );
         expect(response).toEqual(expectedResponse);
       });
+    });
+  });
+
+  describe('-> global search', () => {
+    const emptySearchResponse: SearchResultData = { data: [] as unknown as SearchResultData['data'] };
+
+    it('Should call the personal fuzzy endpoint without query params, when no options are passed', async () => {
+      const { client, headers } = clientAndHeaders({});
+      const getCancellableStub = vi.spyOn(HttpClient.prototype, 'getCancellable').mockReturnValue({
+        promise: Promise.resolve(emptySearchResponse),
+        requestCanceler: { cancel: () => null },
+      });
+
+      const [promise] = client.getGlobalSearchItems('report');
+      await promise;
+
+      expect(getCancellableStub).toHaveBeenCalledWith('fuzzy/report?', headers);
+    });
+
+    it('Should call the workspace fuzzy endpoint, when a workspaceId is passed', async () => {
+      const workspaceId = 'workspace-id';
+      const { client, headers } = clientAndHeaders({});
+      const getCancellableStub = vi.spyOn(HttpClient.prototype, 'getCancellable').mockReturnValue({
+        promise: Promise.resolve(emptySearchResponse),
+        requestCanceler: { cancel: () => null },
+      });
+
+      const [promise] = client.getGlobalSearchItems('report', workspaceId);
+      await promise;
+
+      expect(getCancellableStub).toHaveBeenCalledWith(`workspaces/${workspaceId}/fuzzy/report?`, headers);
+    });
+
+    it('Should keep supporting a numeric offset as third argument', async () => {
+      const { client, headers } = clientAndHeaders({});
+      const getCancellableStub = vi.spyOn(HttpClient.prototype, 'getCancellable').mockReturnValue({
+        promise: Promise.resolve(emptySearchResponse),
+        requestCanceler: { cancel: () => null },
+      });
+
+      const [promise] = client.getGlobalSearchItems('report', undefined, 10);
+      await promise;
+
+      expect(getCancellableStub).toHaveBeenCalledWith('fuzzy/report?offset=10', headers);
+    });
+
+    it('Should serialize all search filters as query params, when options are passed', async () => {
+      const { client, headers } = clientAndHeaders({});
+      const getCancellableStub = vi.spyOn(HttpClient.prototype, 'getCancellable').mockReturnValue({
+        promise: Promise.resolve(emptySearchResponse),
+        requestCanceler: { cancel: () => null },
+      });
+
+      const [promise] = client.getGlobalSearchItems('report', undefined, {
+        offset: 0,
+        type: ['pdf', 'image'],
+        minSize: 1024,
+        maxSize: 5242880,
+        modifiedAfter: '2026-01-01T00:00:00.000Z',
+        modifiedBefore: '2026-06-30T23:59:59.999Z',
+      });
+      await promise;
+
+      expect(getCancellableStub).toHaveBeenCalledWith(
+        'fuzzy/report?offset=0&type=pdf&type=image&minSize=1024&maxSize=5242880' +
+          '&modifiedAfter=2026-01-01T00%3A00%3A00.000Z&modifiedBefore=2026-06-30T23%3A59%3A59.999Z',
+        headers,
+      );
     });
   });
 });

--- a/test/drive/storage/index.test.ts
+++ b/test/drive/storage/index.test.ts
@@ -1032,9 +1032,9 @@ describe('# storage service tests', () => {
   describe('-> global search', () => {
     const emptySearchResponse: SearchResultData = { data: [] as unknown as SearchResultData['data'] };
 
-    it('Should call the personal fuzzy endpoint without query params, when no options are passed', async () => {
+    it('Should post to the personal fuzzy endpoint with an empty body, when no options are passed', async () => {
       const { client, headers } = clientAndHeaders({});
-      const getCancellableStub = vi.spyOn(HttpClient.prototype, 'getCancellable').mockReturnValue({
+      const postCancellableStub = vi.spyOn(HttpClient.prototype, 'postCancellable').mockReturnValue({
         promise: Promise.resolve(emptySearchResponse),
         requestCanceler: { cancel: () => null },
       });
@@ -1042,13 +1042,13 @@ describe('# storage service tests', () => {
       const [promise] = client.getGlobalSearchItems('report');
       await promise;
 
-      expect(getCancellableStub).toHaveBeenCalledWith('fuzzy/report?', headers);
+      expect(postCancellableStub).toHaveBeenCalledWith('fuzzy/report', {}, headers);
     });
 
-    it('Should call the workspace fuzzy endpoint, when a workspaceId is passed', async () => {
+    it('Should post to the workspace fuzzy endpoint, when a workspaceId is passed', async () => {
       const workspaceId = 'workspace-id';
       const { client, headers } = clientAndHeaders({});
-      const getCancellableStub = vi.spyOn(HttpClient.prototype, 'getCancellable').mockReturnValue({
+      const postCancellableStub = vi.spyOn(HttpClient.prototype, 'postCancellable').mockReturnValue({
         promise: Promise.resolve(emptySearchResponse),
         requestCanceler: { cancel: () => null },
       });
@@ -1056,12 +1056,12 @@ describe('# storage service tests', () => {
       const [promise] = client.getGlobalSearchItems('report', workspaceId);
       await promise;
 
-      expect(getCancellableStub).toHaveBeenCalledWith(`workspaces/${workspaceId}/fuzzy/report?`, headers);
+      expect(postCancellableStub).toHaveBeenCalledWith(`workspaces/${workspaceId}/fuzzy/report`, {}, headers);
     });
 
     it('Should keep supporting a numeric offset as third argument', async () => {
       const { client, headers } = clientAndHeaders({});
-      const getCancellableStub = vi.spyOn(HttpClient.prototype, 'getCancellable').mockReturnValue({
+      const postCancellableStub = vi.spyOn(HttpClient.prototype, 'postCancellable').mockReturnValue({
         promise: Promise.resolve(emptySearchResponse),
         requestCanceler: { cancel: () => null },
       });
@@ -1069,31 +1069,29 @@ describe('# storage service tests', () => {
       const [promise] = client.getGlobalSearchItems('report', undefined, 10);
       await promise;
 
-      expect(getCancellableStub).toHaveBeenCalledWith('fuzzy/report?offset=10', headers);
+      expect(postCancellableStub).toHaveBeenCalledWith('fuzzy/report', { offset: 10 }, headers);
     });
 
-    it('Should serialize all search filters as query params, when options are passed', async () => {
+    it('Should send all search filters in the request body, when options are passed', async () => {
       const { client, headers } = clientAndHeaders({});
-      const getCancellableStub = vi.spyOn(HttpClient.prototype, 'getCancellable').mockReturnValue({
+      const postCancellableStub = vi.spyOn(HttpClient.prototype, 'postCancellable').mockReturnValue({
         promise: Promise.resolve(emptySearchResponse),
         requestCanceler: { cancel: () => null },
       });
 
-      const [promise] = client.getGlobalSearchItems('report', undefined, {
+      const filters = {
         offset: 0,
         type: ['pdf', 'image'],
         minSize: 1024,
         maxSize: 5242880,
         modifiedAfter: '2026-01-01T00:00:00.000Z',
         modifiedBefore: '2026-06-30T23:59:59.999Z',
-      });
+      };
+
+      const [promise] = client.getGlobalSearchItems('report', undefined, filters);
       await promise;
 
-      expect(getCancellableStub).toHaveBeenCalledWith(
-        'fuzzy/report?offset=0&type=pdf&type=image&minSize=1024&maxSize=5242880' +
-          '&modifiedAfter=2026-01-01T00%3A00%3A00.000Z&modifiedBefore=2026-06-30T23%3A59%3A59.999Z',
-        headers,
-      );
+      expect(postCancellableStub).toHaveBeenCalledWith('fuzzy/report', filters, headers);
     });
   });
 });


### PR DESCRIPTION
In this PR we extend `getGlobalSearchItems` so it can receive an options object as its third argument, adding the new advanced search filters: `type` (file extensions, plus the reserved value `folder` to include folders, combined with OR), `minSize`/`maxSize` (in bytes, files only) and `modifiedAfter`/`modifiedBefore` (ISO 8601 dates), all serialized as query params and combined with AND by the backend. The category-to-extensions mapping lives in the client (drive-web), so the SDK stays agnostic. The change is backwards compatible: passing a numeric offset as before still works, since the new `GlobalSearchOptions` type is accepted alongside `number`. We also added tests covering the personal and workspace fuzzy endpoints, the legacy numeric offset and the full serialization of the new filters.