### PR TITLE
[MKT_949]:feature/ add turnstileToken for checkout payloads

### DIFF
--- a/src/payments/checkout.ts
+++ b/src/payments/checkout.ts
@@ -30,7 +30,8 @@ export class Checkout {
   /**
    * @description Creates a customer or gets the existing one if it already exists
    * @param country - The country of the customer
-   * @param captchaToken - The captcha token to verify the call
+   * @param captchaToken - The reCAPTCHA token to verify the call (fallback provider)
+   * @param turnstileToken - The Cloudflare Turnstile token to verify the call (primary provider, optional)
    * @param customerName - The name of the customer (optional)
    * @param lineAddress1 - The address of the user (optional)
    * @param lineAddress2 - The second address line of the user (optional)
@@ -48,6 +49,7 @@ export class Checkout {
     city,
     country,
     captchaToken,
+    turnstileToken,
     companyVatId,
     metadata,
   }: CreateCustomerPayload): Promise<{
@@ -64,6 +66,7 @@ export class Checkout {
         country,
         postalCode,
         captchaToken,
+        turnstileToken,
         companyVatId,
         metadata,
       },
@@ -91,6 +94,7 @@ export class Checkout {
     token,
     currency,
     captchaToken,
+    turnstileToken,
     promoCodeId,
   }: CreateSubscriptionPayload): Promise<CreatedSubscriptionData> {
     return this.client.post(
@@ -101,6 +105,7 @@ export class Checkout {
         token,
         currency,
         captchaToken,
+        turnstileToken,
         promoCodeId,
       },
       this.authHeaders(),
@@ -130,6 +135,7 @@ export class Checkout {
     token,
     currency,
     captchaToken,
+    turnstileToken,
     userAddress,
     promoCodeId,
   }: CreatePaymentIntentPayload): Promise<PaymentIntent> {
@@ -141,6 +147,7 @@ export class Checkout {
         token,
         currency,
         captchaToken,
+        turnstileToken,
         userAddress,
         promoCodeId,
       },

--- a/src/payments/checkout.ts
+++ b/src/payments/checkout.ts
@@ -30,8 +30,8 @@ export class Checkout {
   /**
    * @description Creates a customer or gets the existing one if it already exists
    * @param country - The country of the customer
-   * @param captchaToken - The reCAPTCHA token to verify the call (fallback provider)
-   * @param turnstileToken - The Cloudflare Turnstile token to verify the call (primary provider, optional)
+   * @param captchaToken - The reCAPTCHA token to verify the call (fallback provider, optional)
+   * @param turnstileToken - The Cloudflare Turnstile token to verify the call (primary provider)
    * @param customerName - The name of the customer (optional)
    * @param lineAddress1 - The address of the user (optional)
    * @param lineAddress2 - The second address line of the user (optional)

--- a/src/payments/types/index.ts
+++ b/src/payments/types/index.ts
@@ -8,6 +8,7 @@ export interface CreateCustomerPayload {
   country: string;
   postalCode?: string;
   captchaToken: string;
+  turnstileToken?: string;
   companyVatId?: string;
   metadata?: Record<string, string>;
 }
@@ -17,6 +18,7 @@ export interface CreateSubscriptionPayload {
   priceId: string;
   token: string;
   captchaToken: string;
+  turnstileToken?: string;
   currency?: string;
   promoCodeId?: string;
 }
@@ -27,6 +29,7 @@ export interface CreatePaymentIntentPayload {
   token: string;
   currency: string;
   captchaToken: string;
+  turnstileToken?: string;
   userAddress: string;
   promoCodeId?: string;
 }

--- a/src/payments/types/index.ts
+++ b/src/payments/types/index.ts
@@ -7,8 +7,8 @@ export interface CreateCustomerPayload {
   city?: string;
   country: string;
   postalCode?: string;
-  captchaToken: string;
-  turnstileToken?: string;
+  captchaToken?: string;
+  turnstileToken: string;
   companyVatId?: string;
   metadata?: Record<string, string>;
 }
@@ -17,8 +17,8 @@ export interface CreateSubscriptionPayload {
   customerId: string;
   priceId: string;
   token: string;
-  captchaToken: string;
-  turnstileToken?: string;
+  captchaToken?: string;
+  turnstileToken: string;
   currency?: string;
   promoCodeId?: string;
 }
@@ -28,8 +28,8 @@ export interface CreatePaymentIntentPayload {
   priceId: string;
   token: string;
   currency: string;
-  captchaToken: string;
-  turnstileToken?: string;
+  captchaToken?: string;
+  turnstileToken: string;
   userAddress: string;
   promoCodeId?: string;
 }


### PR DESCRIPTION
Adds an optional `turnstileToken` field to the three checkout payloads so the checkout client can forward a Cloudflare Turnstile token to the payments API.