### PR TITLE
[_] Change create user type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -317,7 +317,7 @@ export class Users {
 
   /**
    * Get public key of given email, if not exists it pre-create user with this email
-   * and returns public key
+   * and returns public keys (kyber and ecc) of this user
    * @param email
    * @returns {Promise<UserPublicKeyWithCreationResponse>} A promise that returns the public keys of given user
    */

--- a/src/drive/users/types.ts
+++ b/src/drive/users/types.ts
@@ -56,7 +56,7 @@ export type FriendInvite = { guestEmail: string; host: number; accepted: boolean
 
 export type UserPublicKeyResponse = { publicKey: string; keys?: { ecc: string; kyber: string } };
 
-export type UserPublicKeyWithCreationResponse = { publicKey: string; publicKyberKey: string | undefined };
+export type UserPublicKeyWithCreationResponse = { publicKey: string; publicKyberKey: string };
 
 export type VerifyEmailChangeResponse = {
   oldEmail: string;


### PR DESCRIPTION
Pre-created user always has a Kyber key now. Updating the type will help to simplify the web logic

Call to the server: https://github.com/internxt/sdk/blob/0129d8d57cb4adf2aa54a7779e835d9ab527be01/src/drive/users/index.ts#L325

Endpoin response: https://github.com/internxt/drive-server-wip/blob/951c57d70ba486d7a6d8c20ef308c9145984a631/src/modules/user/user.controller.ts#L890

which calls
https://github.com/internxt/drive-server-wip/blob/master/src/modules/user/user.usecase.ts#L217

