### PR TITLE
[MKT_963]:feat/add impactClickId as metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/payments/checkout.ts
+++ b/src/payments/checkout.ts
@@ -92,6 +92,7 @@ export class Checkout {
     currency,
     captchaToken,
     promoCodeId,
+    impactClickId,
   }: CreateSubscriptionPayload): Promise<CreatedSubscriptionData> {
     return this.client.post(
       '/checkout/subscription',
@@ -102,6 +103,7 @@ export class Checkout {
         currency,
         captchaToken,
         promoCodeId,
+        impactClickId,
       },
       this.authHeaders(),
     );
@@ -132,6 +134,7 @@ export class Checkout {
     captchaToken,
     userAddress,
     promoCodeId,
+    impactClickId,
   }: CreatePaymentIntentPayload): Promise<PaymentIntent> {
     return this.client.post(
       '/checkout/payment-intent',
@@ -143,6 +146,7 @@ export class Checkout {
         captchaToken,
         userAddress,
         promoCodeId,
+        impactClickId,
       },
       this.authHeaders(),
     );

--- a/src/payments/types/index.ts
+++ b/src/payments/types/index.ts
@@ -19,6 +19,7 @@ export interface CreateSubscriptionPayload {
   captchaToken: string;
   currency?: string;
   promoCodeId?: string;
+  impactClickId?: string;
 }
 
 export interface CreatePaymentIntentPayload {
@@ -29,6 +30,7 @@ export interface CreatePaymentIntentPayload {
   captchaToken: string;
   userAddress: string;
   promoCodeId?: string;
+  impactClickId?: string;
 }
 
 export interface PaymentMethodVerificationPayload {


### PR DESCRIPTION
In this PR, we've added the `impactClickId` variable as an optional field for the points where a subscription is created or a payment attempt is made.