### PR TITLE
[PB-6544] Enable invite reencrypt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.21.0",
+  "version": "1.20.3",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -39,10 +39,10 @@ export interface RegisterPreCreatedUser extends RegisterDetails {
   invitationId: string;
 }
 export interface RegisterPreCreatedUserResponse {
-  token: Token;
   newToken: Token;
   user: UserSettings & { referralCode: string };
   uuid: UUID;
+  tmpKeys: UserKeys;
 }
 export interface Keys {
   ecc: {

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -42,7 +42,7 @@ export interface RegisterPreCreatedUserResponse {
   newToken: Token;
   user: UserSettings & { referralCode: string };
   uuid: UUID;
-  tmpKeys: UserKeys;
+  tmpKeys?: UserKeys;
 }
 export interface Keys {
   ecc: {


### PR DESCRIPTION
Return temporary keys so the user can re-encrypt their shared item without making server do it