### PR TITLE
[PB-6513, PB-6515] Add login and pwd change with argon2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/sdk",
   "author": "Internxt <hello@internxt.com>",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "description": "An sdk for interacting with Internxt's services",
   "repository": {
     "type": "git",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -248,7 +248,7 @@ export class Auth {
       token: Token;
       user: UserSettings;
     }>(
-      '/auth/login/access?argon2=true',
+      '/auth/v2/login/access',
       {
         email,
         passwordHash,

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -248,7 +248,7 @@ export class Auth {
       token: Token;
       user: UserSettings;
     }>(
-      '/auth/login-argon2/access',
+      '/auth/login/access?argon2=true',
       {
         email,
         passwordHash,

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -231,6 +231,34 @@ export class Auth {
   }
 
   /**
+   * Tries to log in a user with Argon2
+   * @param email - The user email address
+   * @param passwordHash - The argon2id hash of the user's password
+   * @param tfaCode - The 2 factor authentication code (if 2FA is enabled)
+   */
+  public loginArgon2(
+    email: string,
+    passwordHash: string,
+    tfaCode?: string,
+  ): Promise<{
+    token: Token;
+    user: UserSettings;
+  }> {
+    return this.client.post<{
+      token: Token;
+      user: UserSettings;
+    }>(
+      '/auth/login-argon2/access',
+      {
+        email,
+        passwordHash,
+        tfa: tfaCode,
+      },
+      this.basicHeaders(),
+    );
+  }
+
+  /**
    * Tries to log in a user given its cli login details
    * @param details
    * @param cryptoProvider
@@ -330,6 +358,7 @@ export class Auth {
       .post<{
         sKey: string;
         tfa: boolean | null;
+        saltArgon2: string;
       }>(
         '/auth/login',
         {
@@ -341,6 +370,7 @@ export class Auth {
         return {
           encryptedSalt: data.sKey,
           tfaEnabled: data.tfa === true,
+          saltArgon2: data.saltArgon2,
         };
       });
   }

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -65,6 +65,7 @@ export class UserAccessError extends Error {}
 export interface SecurityDetails {
   encryptedSalt: string;
   tfaEnabled: boolean;
+  saltArgon2: string;
 }
 
 export interface TwoFactorAuthQR {

--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -168,7 +168,7 @@ export class Users {
    */
   public changePasswordArgon2(payload: ChangePasswordArgon2Payload): Promise<string> {
     return this.client.patch(
-      '/users/password-argon2',
+      '/users/password?argon2=true',
       {
         currentPassword: payload.currentPasswordHash,
         newPassword: payload.newPasswordHash,

--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -17,6 +17,7 @@ import {
   UserPublicKeyResponse,
   UserPublicKeyWithCreationResponse,
   VerifyEmailChangeResponse,
+  ChangePasswordArgon2Payload,
 } from './types';
 
 export * as UserTypes from './types';
@@ -154,6 +155,27 @@ export class Users {
         privateKey: payload.keys.encryptedPrivateKey,
         privateKyberKey: payload.keys.encryptedPrivateKyberKey,
         encryptVersion: payload.encryptVersion,
+      },
+      this.headers(),
+    );
+  }
+
+  /**
+   * Updates the authentication credentials with argon2 and invalidates previous tokens
+   * @param payload
+   *
+   * @returns {Promise<string>} A promise that returns new tokens for this user.
+   */
+  public changePasswordArgon2(payload: ChangePasswordArgon2Payload): Promise<string> {
+    return this.client.patch(
+      '/users/password-argon2',
+      {
+        currentPassword: payload.currentPasswordHash,
+        newPassword: payload.newPasswordHash,
+        newSalt: payload.newSalt,
+        mnemonic: payload.encryptedMnemonic,
+        privateKey: payload.keys.encryptedPrivateKey,
+        privateKyberKey: payload.keys.encryptedPrivateKyberKey,
       },
       this.headers(),
     );

--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -170,8 +170,8 @@ export class Users {
     return this.client.patch(
       '/users/v2/password',
       {
-        currentPassword: payload.currentPasswordHash,
-        newPassword: payload.newPasswordHash,
+        currentPasswordHash: payload.currentPasswordHash,
+        newPasswordHash: payload.newPasswordHash,
         newSalt: payload.newSalt,
         mnemonic: payload.encryptedMnemonic,
         privateKey: payload.keys.encryptedPrivateKey,

--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -173,9 +173,9 @@ export class Users {
         currentPasswordHash: payload.currentPasswordHash,
         newPasswordHash: payload.newPasswordHash,
         newSalt: payload.newSalt,
-        mnemonic: payload.encryptedMnemonic,
-        privateKey: payload.keys.encryptedPrivateKey,
-        privateKyberKey: payload.keys.encryptedPrivateKyberKey,
+        encryptedMnemonic: payload.encryptedMnemonic,
+        encryptedPrivateKey: payload.keys.encryptedPrivateKey,
+        encryptedPrivateKyberKey: payload.keys.encryptedPrivateKyberKey,
       },
       this.headers(),
     );

--- a/src/drive/users/index.ts
+++ b/src/drive/users/index.ts
@@ -168,7 +168,7 @@ export class Users {
    */
   public changePasswordArgon2(payload: ChangePasswordArgon2Payload): Promise<string> {
     return this.client.patch(
-      '/users/password?argon2=true',
+      '/users/v2/password',
       {
         currentPassword: payload.currentPasswordHash,
         newPassword: payload.newPasswordHash,

--- a/src/drive/users/types.ts
+++ b/src/drive/users/types.ts
@@ -25,6 +25,17 @@ export interface ChangePasswordPayload {
   encryptedPrivateKey: string;
 }
 
+export interface ChangePasswordArgon2Payload {
+  currentPasswordHash: string;
+  newPasswordHash: string;
+  newSalt: string;
+  encryptedMnemonic: string;
+  keys: {
+    encryptedPrivateKey: string;
+    encryptedPrivateKyberKey: string;
+  };
+}
+
 export interface ChangePasswordPayloadNew {
   currentEncryptedPassword: string;
   newEncryptedPassword: string;


### PR DESCRIPTION
Endpoint for login and password change with Argon2, without sending keys and without encrypting with CRYPTO_SECRET

[PB-6515](https://inxt.atlassian.net/browse/PB-6515)
[PB-6513](https://inxt.atlassian.net/browse/PB-6513)

[PB-6515]: https://inxt.atlassian.net/browse/PB-6515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PB-6513]: https://inxt.atlassian.net/browse/PB-6513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ